### PR TITLE
Update service config to fix autowiring deprecations

### DIFF
--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -129,7 +129,6 @@ services:
         alias: CustomerManagementFrameworkBundle\ActivityStore\ActivityStoreInterface
 
     cmf.activity_manager: '@CustomerManagementFrameworkBundle\ActivityManager\ActivityManagerInterface'
-    CustomerManagementFrameworkBundle\ActivityStore\ActivityManagerInterface: '@CustomerManagementFrameworkBundle\ActivityManager\ActivityManagerInterface'
     CustomerManagementFrameworkBundle\ActivityManager\ActivityManagerInterface: '@CustomerManagementFrameworkBundle\ActivityManager\DefaultActivityManager'
     CustomerManagementFrameworkBundle\ActivityManager\DefaultActivityManager: ~
 

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -128,10 +128,10 @@ services:
     cmf.activity_store:
         alias: CustomerManagementFrameworkBundle\ActivityStore\ActivityStoreInterface
 
-    CustomerManagementFrameworkBundle\ActivityStore\ActivityManagerInterface:
-        class: CustomerManagementFrameworkBundle\ActivityManager\DefaultActivityManager
-    cmf.activity_manager:
-        alias: CustomerManagementFrameworkBundle\ActivityStore\ActivityManagerInterface
+    cmf.activity_manager: '@CustomerManagementFrameworkBundle\ActivityManager\ActivityManagerInterface'
+    CustomerManagementFrameworkBundle\ActivityStore\ActivityManagerInterface: '@CustomerManagementFrameworkBundle\ActivityManager\ActivityManagerInterface'
+    CustomerManagementFrameworkBundle\ActivityManager\ActivityManagerInterface: '@CustomerManagementFrameworkBundle\ActivityManager\DefaultActivityManager'
+    CustomerManagementFrameworkBundle\ActivityManager\DefaultActivityManager: ~
 
     cmf.activity_store_entry:
         class: CustomerManagementFrameworkBundle\Model\ActivityStoreEntry\DefaultActivityStoreEntry
@@ -204,8 +204,9 @@ services:
     cmf.rest.deletions_handler:
         class: CustomerManagementFrameworkBundle\RESTApi\DeletionsHandler
 
-    cmf.encryption_service:
-        class: CustomerManagementFrameworkBundle\Encryption\DefaultEncryptionService
+    cmf.encryption_service: '@CustomerManagementFrameworkBundle\Encryption\EncryptionServiceInterface'
+    CustomerManagementFrameworkBundle\Encryption\EncryptionServiceInterface: '@CustomerManagementFrameworkBundle\Encryption\DefaultEncryptionService'
+    CustomerManagementFrameworkBundle\Encryption\DefaultEncryptionService:
         arguments:
             - '%pimcore_customer_management_framework.encryption.secret%'
 

--- a/src/Resources/config/services_security.yml
+++ b/src/Resources/config/services_security.yml
@@ -3,8 +3,11 @@ services:
         autowire: true
         autoconfigure: true
 
+    CustomerManagementFrameworkBundle\Security\Authentication\LoginManagerInterface: '@CustomerManagementFrameworkBundle\Security\Authentication\LoginManager'
     CustomerManagementFrameworkBundle\Security\Authentication\LoginManager:
         arguments:
+            $firewallMap: '@security.firewall.map'
+            $sessionStrategy: '@security.authentication.session_strategy'
             $defaultUserChecker: '@security.user_checker'
 
     # The user provider loads users by Username.
@@ -26,8 +29,9 @@ services:
             - Pimcore\Security\Encoder\PasswordFieldEncoder
             - ['password']
 
-    cmf.security.sso.identity_service:
-        class: CustomerManagementFrameworkBundle\Security\SsoIdentity\DefaultSsoIdentityService
+    cmf.security.sso.identity_service: '@CustomerManagementFrameworkBundle\Security\SsoIdentity\SsoIdentityServiceInterface'
+    CustomerManagementFrameworkBundle\Security\SsoIdentity\SsoIdentityServiceInterface: '@CustomerManagementFrameworkBundle\Security\SsoIdentity\DefaultSsoIdentityService'
+    CustomerManagementFrameworkBundle\Security\SsoIdentity\DefaultSsoIdentityService:
         arguments: ['@cmf.customer_provider']
         calls:
              - [setLogger, ['@cmf.logger']]

--- a/src/Resources/config/services_security_oauth_client.yml
+++ b/src/Resources/config/services_security_oauth_client.yml
@@ -3,10 +3,14 @@ services:
         autowire: true
         autoconfigure: true
 
+    CustomerManagementFrameworkBundle\Security\OAuth\AccountConnectorInterface: '@CustomerManagementFrameworkBundle\Security\OAuth\AccountConnector'
     CustomerManagementFrameworkBundle\Security\OAuth\AccountConnector: ~
 
-    CustomerManagementFrameworkBundle\Security\OAuth\OAuthRegistrationHandler: ~
+    CustomerManagementFrameworkBundle\Security\OAuth\OAuthRegistrationHandler:
+        arguments:
+            $oAuthUtils: '@hwi_oauth.security.oauth_utils'
 
+    CustomerManagementFrameworkBundle\Security\OAuth\TokenStorageInterface: '@CustomerManagementFrameworkBundle\Security\OAuth\SessionTokenStorage'
     CustomerManagementFrameworkBundle\Security\OAuth\SessionTokenStorage: ~
 
     # OAuth user provider


### PR DESCRIPTION
Adds alias definitions for interfaces to fix autowiring warnings as `User Deprecated: Autowiring services based on the types they implement is deprecated since Symfony 3.3 and won't be supported in version 4.0. You should rename (or alias) the "cmf.encryption_service" service to "CustomerManagementFrameworkBundle\Encryption\EncryptionServiceInterface" instead.` and adds explicit wiring for arguments which trigger autowiring warnings.