### PR TITLE
move DefaultAbstractUserawareCustomer functionality to trait

### DIFF
--- a/src/Model/AbstractCustomer/DefaultAbstractUserawareCustomer.php
+++ b/src/Model/AbstractCustomer/DefaultAbstractUserawareCustomer.php
@@ -16,46 +16,10 @@
 namespace CustomerManagementFrameworkBundle\Model\AbstractCustomer;
 
 use CustomerManagementFrameworkBundle\Model\AbstractCustomer;
-use Pimcore\Model\DataObject\ClassDefinition\Data\Password;
 use Symfony\Component\Security\Core\User\UserInterface;
+use CustomerManagementFrameworkBundle\Model\Traits;
 
 abstract class DefaultAbstractUserawareCustomer extends AbstractCustomer implements UserInterface
 {
-    public function getRoles()
-    {
-        return ['ROLE_USER'];
-    }
-
-    /**
-     * @inheritDoc
-     */
-    public function getSalt()
-    {
-        // user has no salt as we use password_hash
-        // which handles the salt by itself
-        return null;
-    }
-
-    /**
-     * By default email is used as username
-     *
-     * @return string
-     */
-    public function getUsername()
-    {
-        return $this->getEmail();
-    }
-
-    /**
-     * Trigger the hash calculation to remove the plain text password from the instance. This
-     * is necessary to make sure no plain text passwords are serialized.
-     *
-     * @inheritDoc
-     */
-    public function eraseCredentials()
-    {
-        /** @var Password $field */
-        $field = $this->getClass()->getFieldDefinition('password');
-        $field->getDataForResource($this->getPassword(), $this);
-    }
+    use Traits\DefaultUserawareCustomerTrait;
 }

--- a/src/Model/Traits/DefaultUserawareCustomerTrait.php
+++ b/src/Model/Traits/DefaultUserawareCustomerTrait.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace CustomerManagementFrameworkBundle\Model\Traits;
+
+use Pimcore\Model\DataObject\ClassDefinition\Data\Password;
+
+trait DefaultUserawareCustomerTrait
+{
+    public function getRoles()
+    {
+        return ['ROLE_USER'];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getSalt()
+    {
+        // user has no salt as we use password_hash
+        // which handles the salt by itself
+        return null;
+    }
+
+    /**
+     * By default email is used as username
+     *
+     * @return string
+     */
+    public function getUsername()
+    {
+        return $this->getEmail();
+    }
+
+    /**
+     * Trigger the hash calculation to remove the plain text password from the instance. This
+     * is necessary to make sure no plain text passwords are serialized.
+     *
+     * @inheritDoc
+     */
+    public function eraseCredentials()
+    {
+        /** @var Password $field */
+        $field = $this->getClass()->getFieldDefinition('password');
+        $field->getDataForResource($this->getPassword(), $this);
+    }
+}


### PR DESCRIPTION
regarding #25 it would also be nice to move the default useraware customer functionality to a trait since this will make dealing with it in other bundles more convenient

@markus-moser 