### PR TITLE
skip duplicates check if the customer is inactive

### DIFF
--- a/src/CustomerSaveManager/DefaultCustomerSaveManager.php
+++ b/src/CustomerSaveManager/DefaultCustomerSaveManager.php
@@ -133,7 +133,7 @@ class DefaultCustomerSaveManager implements CustomerSaveManagerInterface
     public function preAdd(CustomerInterface $customer)
     {
         if ($customer->getPublished()) {
-            $this->validateOnSave($customer);
+            $this->validateOnSave($customer, $customer->getActive());
         }
 
         $this->rememberOriginalCustomer($customer);
@@ -185,7 +185,7 @@ class DefaultCustomerSaveManager implements CustomerSaveManagerInterface
         if ($this->saveOptions->isSaveHandlersExecutionEnabled()) {
             $this->applySaveHandlers($customer, 'preUpdate', true);
         }
-        $this->validateOnSave($customer, true);
+        $this->validateOnSave($customer, $customer->getActive());
         $this->applyNamingScheme($customer);
     }
 


### PR DESCRIPTION
the duplicate-check should only be executed if the customer is active. field-validation should not be skipped though since this may lead to problems setting an inactive customer active