### PR TITLE
only validate Duplicates if the customer is published and active

### DIFF
--- a/src/CustomerSaveValidator/DefaultCustomerSaveValidator.php
+++ b/src/CustomerSaveValidator/DefaultCustomerSaveValidator.php
@@ -99,7 +99,7 @@ class DefaultCustomerSaveValidator implements CustomerSaveValidatorInterface
 
     protected function validateDuplicates(CustomerInterface $customer)
     {
-        if ($this->checkForDuplicates) {
+        if ($this->checkForDuplicates && $customer->getActive() && $customer->getPublished()) {
             $duplicates = \Pimcore::getContainer()->get('cmf.customer_duplicates_service')->getDuplicatesOfCustomer(
                 $customer
             );


### PR DESCRIPTION
a better way to skip duplicate checks as merged in https://github.com/pimcore/customer-data-framework/pull/61 would be this way. due to the check of isPublished on preAdd and not on preUpdate on the old PR it may be inconsistent

if you favor this PR just revert the last commit with https://github.com/pimcore/customer-data-framework/pull/62 and merge this PR

@fashxp @markus-moser 