### PR TITLE
Use DependentBundleInterface to define dependency on HWIOAuthBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "hwi/oauth-bundle": "^0.5.3",
         "mtdowling/cron-expression": "^1.1.0",
         "pear/archive_tar": "^1.4.3",
-        "pimcore/core-version": "~5.1.0",
+        "pimcore/core-version": "~5.1.2",
         "pimcore/number-sequence-generator": "^1.0.1",
         "pimcore/object-merger": "~1.1",
         "pimcore/search-query-parser": "^1.2.4"

--- a/frontend-samples/sso_client/src/AppBundle/AppBundle.php
+++ b/frontend-samples/sso_client/src/AppBundle/AppBundle.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * Pimcore Customer Management Framework Bundle
  * Full copyright and license information is available in
@@ -11,8 +13,16 @@
 
 namespace AppBundle;
 
+use HWI\Bundle\OAuthBundle\HWIOAuthBundle;
+use Pimcore\HttpKernel\Bundle\DependentBundleInterface;
+use Pimcore\HttpKernel\BundleCollection\BundleCollection;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class AppBundle extends Bundle
+class AppBundle extends Bundle implements DependentBundleInterface
 {
+    public static function registerDependentBundles(BundleCollection $collection)
+    {
+        // activate bundle for SSO oauth login/register functionality
+        $collection->addBundle(HWIOAuthBundle::class);
+    }
 }


### PR DESCRIPTION
Can be merged as soon as Pimcore 5.1.2 is released as it relies on pimcore/pimcore#2517 .