### PR TITLE
refactore active condition for the customerlist

### DIFF
--- a/src/CustomerProvider/CustomerProviderInterface.php
+++ b/src/CustomerProvider/CustomerProviderInterface.php
@@ -113,4 +113,10 @@ interface CustomerProviderInterface
      * @return void
      */
     public function setParentPath($parentPath);
+
+    /**
+     * @param \Pimcore\Model\DataObject\Listing\Concrete $list
+     * @return void
+     */
+    public function setActiveCondition($list);
 }

--- a/src/CustomerProvider/CustomerProviderInterface.php
+++ b/src/CustomerProvider/CustomerProviderInterface.php
@@ -118,5 +118,5 @@ interface CustomerProviderInterface
      * @param \Pimcore\Model\DataObject\Listing\Concrete $list
      * @return void
      */
-    public function setActiveCondition($list);
+    public function addActiveCondition($list);
 }

--- a/src/CustomerProvider/DefaultCustomerProvider.php
+++ b/src/CustomerProvider/DefaultCustomerProvider.php
@@ -204,7 +204,7 @@ class DefaultCustomerProvider implements CustomerProviderInterface
     {
         $list = $this->getList();
         $list->setUnpublished(false);
-        $this->setActiveCondition($list);
+        $this->addActiveCondition($list);
         $list->addConditionParam('trim(email) like ?', [trim($email)]);
 
         if ($list->count() > 1) {
@@ -252,7 +252,7 @@ class DefaultCustomerProvider implements CustomerProviderInterface
     /**
      * @param \Pimcore\Model\DataObject\Listing\Concrete $list
      */
-    public function setActiveCondition($list) {
-        $list->setCondition('active = 1');
+    public function addActiveCondition($list) {
+        $list->addConditionParam('active = 1');
     }
 }

--- a/src/CustomerProvider/DefaultCustomerProvider.php
+++ b/src/CustomerProvider/DefaultCustomerProvider.php
@@ -204,7 +204,8 @@ class DefaultCustomerProvider implements CustomerProviderInterface
     {
         $list = $this->getList();
         $list->setUnpublished(false);
-        $list->addConditionParam('active = 1 and trim(email) like ?', [trim($email)]);
+        $this->setActiveCondition($list);
+        $list->addConditionParam('trim(email) like ?', [trim($email)]);
 
         if ($list->count() > 1) {
             throw new \Exception(sprintf('multiple active and published customers with email %s found', $email));
@@ -246,5 +247,12 @@ class DefaultCustomerProvider implements CustomerProviderInterface
         $className = $this->getDiClassName();
 
         return call_user_func_array([$className, $method], $arguments);
+    }
+
+    /**
+     * @param \Pimcore\Model\DataObject\Listing\Concrete $list
+     */
+    public function setActiveCondition($list) {
+        $list->setCondition('active = 1');
     }
 }

--- a/src/DuplicatesIndex/DefaultMariaDbDuplicatesIndex.php
+++ b/src/DuplicatesIndex/DefaultMariaDbDuplicatesIndex.php
@@ -81,8 +81,10 @@ class DefaultMariaDbDuplicatesIndex implements DuplicatesIndexInterface
 
         $logger->notice('tables truncated');
 
-        $customerList = \Pimcore::getContainer()->get('cmf.customer_provider')->getList();
-        $customerList->setCondition('active = 1');
+        $customerProvider = \Pimcore::getContainer()->get('cmf.customer_provider');
+        $customerList = $customerProvider->getList();
+
+        $customerProvider->setActiveCondition($customerList);
         $customerList->setOrderKey('o_id');
 
         $paginator = new Paginator($customerList);

--- a/src/DuplicatesIndex/DefaultMariaDbDuplicatesIndex.php
+++ b/src/DuplicatesIndex/DefaultMariaDbDuplicatesIndex.php
@@ -84,7 +84,7 @@ class DefaultMariaDbDuplicatesIndex implements DuplicatesIndexInterface
         $customerProvider = \Pimcore::getContainer()->get('cmf.customer_provider');
         $customerList = $customerProvider->getList();
 
-        $customerProvider->setActiveCondition($customerList);
+        $customerProvider->addActiveCondition($customerList);
         $customerList->setOrderKey('o_id');
 
         $paginator = new Paginator($customerList);

--- a/src/Security/UserProvider/CustomerObjectUserProvider.php
+++ b/src/Security/UserProvider/CustomerObjectUserProvider.php
@@ -48,7 +48,8 @@ class CustomerObjectUserProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         $list = $this->customerProvider->getList();
-        $list->setCondition(sprintf('active = 1 and %s = ?', $this->usernameField), $username);
+        $this->customerProvider->setActiveCondition($list);
+        $list->setCondition(sprintf('%s = ?', $this->usernameField), $username);
 
         if (!$customer = $list->current()) {
             throw new UsernameNotFoundException(sprintf('Customer "%s" was not found', $username));

--- a/src/Security/UserProvider/CustomerObjectUserProvider.php
+++ b/src/Security/UserProvider/CustomerObjectUserProvider.php
@@ -48,8 +48,8 @@ class CustomerObjectUserProvider implements UserProviderInterface
     public function loadUserByUsername($username)
     {
         $list = $this->customerProvider->getList();
-        $this->customerProvider->setActiveCondition($list);
         $list->setCondition(sprintf('%s = ?', $this->usernameField), $username);
+        $this->customerProvider->addActiveCondition($list);
 
         if (!$customer = $list->current()) {
             throw new UsernameNotFoundException(sprintf('Customer "%s" was not found', $username));


### PR DESCRIPTION
Adds a method 'setActiveCondition' to the DefaultCustomerProvider. 

This method can be easily overwritten when you want to use a different field for the 'active' flag.