### PR TITLE
Return correct option value in DefaultSegmentBuilderExecutor

### DIFF
--- a/src/SegmentManager/SegmentBuilderExecutor/DefaultSegmentBuilderExecutor.php
+++ b/src/SegmentManager/SegmentBuilderExecutor/DefaultSegmentBuilderExecutor.php
@@ -325,8 +325,8 @@ class DefaultSegmentBuilderExecutor implements SegmentBuilderExecutorInterface
 
     protected function getIntOption(array $options, $option)
     {
-        return isset($options['pageSize']) && (is_int($options['pageSize']) || ctype_digit($options['pageSize']))
-            ? (int)$options['pageSize'] : null;
+        return isset($options[$option]) && (is_int($options[$option]) || ctype_digit($options[$option]))
+            ? (int)$options[$option] : null;
     }
 
     /**


### PR DESCRIPTION
I was wondering why the segment builder always started at the last page. Turns out that there was a value hardcoded in `DefaultSegmentBuilderExecutor`, so that the wrong option was returned for all calls to `getIntOption`.
I've replaced the hardcoded value with the `$option` parameter that was already present in the function.