### PR TITLE
updated for pimcore 5.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,12 @@ Following aspects are short cuts into the documentation for start working with t
 ## Contributing and Development
 
 For details see our [Contributing guide](CONTRIBUTING.md).
+
+
+## Running with Pimcore < 5.4
+With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work 
+with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
+```
+    # rewrite rule for pre pimcore 5.4 core static files
+    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
+``` 

--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "php-http/guzzle6-adapter": "^1.1",
         "mtdowling/cron-expression": "^1.1.0",
         "pear/archive_tar": "^1.4.3",
-        "pimcore/core-version": ">=5.2.0 <5.4",
+        "pimcore/core-version": ">=5.2.0 <5.5",
         "pimcore/number-sequence-generator": "^1.0.1",
-        "pimcore/object-merger": "~1.1",
+        "pimcore/object-merger": "~1.2",
         "pimcore/search-query-parser": "^1.2.4"
     },
     "require-dev": {

--- a/src/Resources/public/css/pimcore.css
+++ b/src/Resources/public/css/pimcore.css
@@ -1,48 +1,48 @@
 #pimcore_menu_cmf {
-    background-image: url(/pimcore/static6/img/flat-color-icons/contacts.svg) !important;
+    background-image: url(/bundles/pimcoreadmin/img/flat-color-icons/contacts.svg) !important;
 }
 
 .pimcore_icon_activities {
-    background: url(/pimcore/static6/img/flat-color-icons/sports_mode.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/sports_mode.svg) center center no-repeat !important;
 }
 
 .pimcore_icon_customers {
     background: url(/bundles/pimcorecustomermanagementframework/icons/customer.svg) center center no-repeat !important;
 }
 .pimcore_icon_customerduplicates {
-    background: url(/pimcore/static6/img/flat-color-icons/copy.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/copy.svg) center center no-repeat !important;
 }
 
 .pimcore_icon_customerautomationrules {
-    background: url(/pimcore/static6/img/flat-color-icons/services.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/services.svg) center center no-repeat !important;
 }
 
 .plugin_cmf_icon_rule_enabled {
-    background: url("/pimcore/static6/img/flat-color-icons/publish.svg") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/publish.svg") no-repeat scroll left center transparent !important;
 }
 .plugin_cmf_icon_rule_disabled {
-    background: url("/pimcore/static6/img/flat-color-icons/cancel.svg") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/cancel.svg") no-repeat scroll left center transparent !important;
 }
 
 
 /** Customer Automation Rules Tabs **/
 .plugin_cmf_icon_rule_settings {
-    background: url("/pimcore/static6/img/flat-color-icons/settings.svg") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/settings.svg") no-repeat scroll left center transparent !important;
 }
 .plugin_cmf_icon_rule_triggers {
-    background: url("/pimcore/static6/img/flat-color-icons/phone.svg") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/phone.svg") no-repeat scroll left center transparent !important;
 }
 .plugin_cmf_icon_rule_conditions {
-    background: url("/pimcore/static6/img/flat-color-icons/binoculars.svg") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/binoculars.svg") no-repeat scroll left center transparent !important;
 }
 .plugin_cmf_icon_rule_actions {
-    background: url("/pimcore/static6/img/flat-color-icons/flash_on.svg") no-repeat scroll left center transparent !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/flash_on.svg") no-repeat scroll left center transparent !important;
 }
 
 /** Triggers & Actions **/
 
 .plugin_cmf_icon_actiontriggerrule_NewActivity {
-    background: url(/pimcore/static6/img/flat-color-icons/sports_mode.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/sports_mode.svg) center center no-repeat !important;
 }
 
 .plugin_cmf_icon_actiontriggerrule_ExecuteSegmentBuilders  {
@@ -50,11 +50,11 @@
 }
 
 .plugin_cmf_icon_actiontriggerrule_Cron {
-    background: url(/pimcore/static6/img/flat-color-icons/clock.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/clock.svg) center center no-repeat !important;
 }
 
 .plugin_cmf_icon_actiontriggerrule_CountActivities {
-    background: url(/pimcore/static6/img/flat-color-icons/sports_mode.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/sports_mode.svg) center center no-repeat !important;
 }
 
 .plugin_cmf_icon_actiontriggerrule_AddSegment,
@@ -70,7 +70,7 @@
 .plugin_cmf_icon_actiontriggerrule_TargetGroupAssigned,
 .plugin_cmf_icon_actiontriggerrule_CountTargetGroupWeight,
 .plugin_cmf_icon_actiontriggerrule_AddTargetGroupSegment {
-    background: url(/pimcore/static6/img/flat-color-icons/manager.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/manager.svg) center center no-repeat !important;
 }
 
 .plugin_cmf_icon_actiontriggerrule_ChangeFieldValue,.plugin_cmf_icon_actiontriggerrule_Customer {
@@ -78,11 +78,11 @@
 }
 
 .pimcore_icon_newsletter_enqueue_all_customers {
-    background: url(/pimcore/static6/img/flat-color-icons/address_book.svg) center center no-repeat !important;
+    background: url(/bundles/pimcoreadmin/img/flat-color-icons/address_book.svg) center center no-repeat !important;
 }
 
 #pimcore_bundle_customerManagementFramework_newsletter_queue_status {
-    background-image: url(/pimcore/static6/img/flat-color-icons/address_book.svg) !important;
+    background-image: url(/bundles/pimcoreadmin/img/flat-color-icons/address_book.svg) !important;
     filter: grayscale(0%) !important;
     -webkit-filter: grayscale(0%) !important;
     position: relative;
@@ -101,5 +101,5 @@
 
 
 .plugin_cmf_icon_export_action {
-    background: url("/pimcore/static6/img/flat-color-icons/export.svg") center center no-repeat !important;
+    background: url("/bundles/pimcoreadmin/img/flat-color-icons/export.svg") center center no-repeat !important;
 }

--- a/src/Resources/public/js/SegmentAddressSource.js
+++ b/src/Resources/public/js/SegmentAddressSource.js
@@ -60,7 +60,7 @@ pimcore.document.newsletters.addressSourceAdapters.SegmentAddressSource = Class.
                     flex: 1,
                     items: [{
                         tooltip: t('remove'),
-                        icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                        icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                         handler: function (grid, rowIndex) {
                             grid.getStore().removeAt(rowIndex);
                         }.bind(this)

--- a/src/Resources/public/js/SegmentAssignmentView.js
+++ b/src/Resources/public/js/SegmentAssignmentView.js
@@ -188,7 +188,7 @@ pimcore.plugin.customermanagementframework.segmentAssignmentTab = Class.create({
                     flex: 1,
                     items: [{
                         tooltip: t('remove'),
-                        icon: "/pimcore/static6/img/flat-color-icons/delete.svg",
+                        icon: "/bundles/pimcoreadmin/img/flat-color-icons/delete.svg",
                         handler: function (grid, rowIndex) {
                             grid.getStore().removeAt(rowIndex);
                         }.bind(this)


### PR DESCRIPTION
## For running with Pimcore < 5.4
With Pimcore 5.4 the location of static Pimcore files like icons has changed. In order to make this bundle work with Pimcore < 5.4, please add following rewrite rule to your `.htaccess`.
```
    # rewrite rule for pre pimcore 5.4 core static files
    RewriteRule ^bundles/pimcoreadmin/(.*) /pimcore/static6/$1 [PT,L]
``` 
