### PR TITLE
Fix ApplicationLoggerDb() instantiation

### DIFF
--- a/src/Traits/ApplicationLoggerAware.php
+++ b/src/Traits/ApplicationLoggerAware.php
@@ -40,11 +40,7 @@ trait ApplicationLoggerAware
         if (null === $this->logger) {
             $logger = new ApplicationLogger();
 
-            if(\Pimcore\Version::getRevision() < 143) {
-                $dbWriter = new ApplicationLoggerDb('notice');
-            } else {
-                $dbWriter = new ApplicationLoggerDb(Db::get(),'notice');
-            }
+            $dbWriter = new ApplicationLoggerDb(Db::get(),'notice');
             $logger->addWriter($dbWriter);
 
             if ($this->loggerComponent) {


### PR DESCRIPTION
When running `bin/console cmf:newsletter-sync --enqueue-all-customers -c` I was getting the error:

 `Argument 1 passed to Pimcore\Log\Handler\ApplicationLoggerDb::__construct() must be an instance of Pimcore\Db\Connection, string given, called in /var/www/html/vendor/pimcore/customer-management-framework-bundle/src/Traits/ApplicationLoggerAware.php on line 44`

It looks like the referenced file is running a check against the Pimcore build number, which was deprecated in 5.4.0. The logic is failing and as such, the `ApplicationLoggerDb` class is not being instantiated correctly.

The offending code on lines 43 to 47 is:

```
if(\Pimcore\Version::getRevision() < 143) {
    $dbWriter = new ApplicationLoggerDb('notice');
} else {
    $dbWriter = new ApplicationLoggerDb(Db::get(),'notice');
}
```

If `Db::get()` is added as the first argument to the constructor in the if-statement, everything works as it should.

It seems that the Customer Data Framework Bundle is requiring Pimcore version 5.2.0 or above, and the build number on that is 206. With that in mind, can't this version check be eliminated and `ApplicationLoggerDb()` just instantiated correctly?