### PR TITLE
Wrong list permission filter for root workspace

### DIFF
--- a/src/Listing/Filter/Permission.php
+++ b/src/Listing/Filter/Permission.php
@@ -77,10 +77,11 @@ class Permission extends AbstractFilter implements OnCreateQueryFilterInterface
         foreach($workspaces as $workspace) {
             // if user is allowed to list content -> add to allow conditions
             if($workspace->getList()) {
+                $cPath = $workspace->getCpath();
+                $cPath = $cPath === "/" ? "" : $cPath;
                 // prepare condition to allow sub paths (with wildcard) and path itself (with equation)
                 $condition = sprintf("(CONCAT(o_path,o_key) LIKE '%s/%%' OR CONCAT(o_path,o_key) = '%s')",
-                    $workspace->getCpath(),
-                    $workspace->getCpath());
+                    $cPath, $cPath);
                 // add allow condition
                 $allowConditions[] = $condition;
             } // if user is not allowed to list content -> add to deny conditions


### PR DESCRIPTION
In the user permission filter for the customer listing, if the workspace is the root workspace  `/` the condition will be `LIKE '//%'`, which then results in a  no-results list.