### PR TITLE
Fix admin panel filtering

### DIFF
--- a/src/Controller/Admin/ActivitiesController.php
+++ b/src/Controller/Admin/ActivitiesController.php
@@ -61,6 +61,8 @@ class ActivitiesController extends \Pimcore\Bundle\AdminBundle\Controller\AdminC
             if ($type = $request->get('type')) {
                 $select = $list->getQuery(false);
                 $select->where('type = ?', $type);
+                $condition = implode(' ', $list->getQuery()->getPart('where'));
+                $list->setCondition($condition);
             }
 
             $paginator = new Paginator($list);


### PR DESCRIPTION
Currently filtering in admin panel (customer perspective) is not working. This fix allows admin to filter customer activities based on their type.