### PR TITLE
Allow non-int class ids

### DIFF
--- a/src/Listing/Filter/AbstractFilter.php
+++ b/src/Listing/Filter/AbstractFilter.php
@@ -34,7 +34,7 @@ abstract class AbstractFilter
             return $this->tableName;
         }
 
-        return $prefix.(int)$classId;
+        return $prefix.$classId;
     }
 
     /**

--- a/src/Security/SsoIdentity/DefaultSsoIdentityService.php
+++ b/src/Security/SsoIdentity/DefaultSsoIdentityService.php
@@ -91,7 +91,7 @@ class DefaultSsoIdentityService implements SsoIdentityServiceInterface
     {
         $select = Db::get()
             ->select()
-            ->from(sprintf('object_relations_%d', $this->customerProvider->getCustomerClassId()), ['src_id'])
+            ->from('object_relations_'.$this->customerProvider->getCustomerClassId(), ['src_id'])
             ->where('fieldname = ?', 'ssoIdentities')
             ->where('dest_id = ?', $ssoIdentity->getId());
 


### PR DESCRIPTION
As of build 270, Pimcore allows for non-int class ids (see https://github.com/pimcore/pimcore/issues/2916). This commit fixes a couple places where the class id was (unnecessarily) cast to an int.