### PR TITLE
Added support for Mailchimps multi-value merge-field ADDRESS.

### DIFF
--- a/doc/03_Configuration.md
+++ b/doc/03_Configuration.md
@@ -33,6 +33,35 @@ services:
             - m/d/Y
             - Y-m-d
 
+    # Special data transformer to handle multi-value merge field.
+    appbundle.cmf.mailchimp.address-addr1-transformer:
+      class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer\Address
+      arguments:
+        - addr1
+    appbundle.cmf.mailchimp.address-addr2-transformer:
+      class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer\Address
+      arguments:
+        - addr2
+    appbundle.cmf.mailchimp.address-zip-transformer:
+      class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer\Address
+      arguments:
+        - zip
+    appbundle.cmf.mailchimp.address-city-transformer:
+      class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer\Address
+      arguments:
+        - city
+        - true
+    appbundle.cmf.mailchimp.address-state-transformer:
+      class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer\Address
+      arguments:
+        - state
+        - true
+    appbundle.cmf.mailchimp.address-country-transformer:
+      class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer\Address
+      arguments:
+        - country
+        - true
+
     appbundle.cmf.mailchimp.handler.list1:
         class: CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp
         autowire: true
@@ -58,12 +87,22 @@ services:
             # Mapping of Pimcore data object attributes => Mailchimp merge fields
             - firstname: FNAME
               lastname: LNAME
-              street: STREET
+              # See the data transformer below why we can map muliple fields to 
+              # the same merge field.
+              street: ADDRESS
+              zip: ADDRESS
+              city: ADDRESS
+              countryCode: ADDRESS
               birthDate: BIRTHDATE
 
-            # Special data transfromer for the birthDate field. 
+            # Special data transformer for the birthDate field. 
             # This ensures that the correct data format will be used.
             - birthDate: '@appbundle.cmf.mailchimp.birthdate-transformer'
+              # Special data transformer for the multi-value field ADDRESS. 
+              street: '@appbundle.cmf.mailchimp.address-addr1-transformer'
+              zip: '@appbundle.cmf.mailchimp.address-zip-transformer'
+              city: '@appbundle.cmf.mailchimp.address-city-transformer'
+              countryCode: '@appbundle.cmf.mailchimp.address-country-transformer'
 
         tags: [cmf.newsletter_provider_handler]
         

--- a/src/Newsletter/ProviderHandler/Mailchimp.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp.php
@@ -509,7 +509,15 @@ class Mailchimp implements NewsletterProviderHandlerInterface
         foreach (array_keys($mergeFieldsMapping) as $field) {
             $mapping = $this->mapMergeField($field, $customer);
 
-            $mergeFields[$mapping['field']] = $mapping['value'];
+            // Check if this is a multi-value field e.g. ADDRESS and needs
+            // merging itself.
+            if (isset($mergeFields[$mapping['field']]) && is_array($mergeFields[$mapping['field']])) {
+              $mergeFields[$mapping['field']] += $mapping['value'];
+            }
+            else {
+              $mergeFields[$mapping['field']] = $mapping['value'];
+            }
+
         }
 
         $emailCleaner = new Email();

--- a/src/Newsletter/ProviderHandler/Mailchimp/DataTransformer/Address.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp/DataTransformer/Address.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer;
+
+/**
+ * Class Address
+ *
+ * Format allowed: https://us1.api.mailchimp.com/schema/3.0/Lists/Members/MergeField.json
+ *
+ * @package DobiBundle\Newsletter\ProviderHandler\Mailchimp\DataTransformer
+ */
+class Address implements MailchimpDataTransformerInterface
+{
+
+  /**
+   * The address property the given value represents.
+   * @var string
+   */
+  protected $address_property;
+
+  /**
+   * Sets an empty state dummy if set to true.
+   * @var bool
+   */
+  protected $stateDummy = FALSE;
+
+  public function __construct($address_property, $stateDummy = FALSE) {
+    $this->address_property = $address_property;
+    $this->stateDummy = $stateDummy;
+  }
+
+  public function transformFromPimcoreToMailchimp($data)
+  {
+    $data = [$this->address_property => $data];
+    if ($this->stateDummy) {
+      $data['state'] = '';
+    }
+    return $data;
+  }
+
+  public function transformFromMailchimpToPimcore($data)
+  {
+    if (!isset($data[$this->address_property])) {
+      return null;
+    }
+
+    return $data[$this->address_property];
+  }
+
+  public function didMergeFieldDataChange($pimcoreData, $mailchimpImportData)
+  {
+    return !(!is_null($pimcoreData) && isset($mailchimpImportData[$this->address_property]) && $pimcoreData == $mailchimpImportData[$this->address_property]);
+  }
+}


### PR DESCRIPTION
Currently only "simple" Mailchimp merge-fields are supported.
However, Mailchimp has the complex "field-type" ADDRESS which accepts properties as defined here: https://us1.api.mailchimp.com/schema/3.0/Lists/Members/MergeField.json

The changes made allow to stitch data from multiple fields together into a single merge field.
Further the changes provide a data transformer that allows to set the properties of the ADDRESS field by mapping the proper service name. It also provides a way to add a dummy `state` property as this isn't used in all countries but is a required property.

This might be an API change as it changes the behavior in case someone sets a merge field multiple types with a value of the type array.
Other than that the changes should be fully backward compatible with existing installations.
