### PR TITLE
Update guzzle6-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "guzzlehttp/guzzle": ">=4.1.4 <7.0",
         "hwi/oauth-bundle": "~0.6.2",
         "php-http/httplug-bundle": "~1.10.0",
-        "php-http/guzzle6-adapter": "^1.1",
+        "php-http/guzzle6-adapter": "^2.0",
         "mtdowling/cron-expression": "^1.1.0",
         "pear/archive_tar": "^1.4.3",
         "pimcore/pimcore": ">=5.4 <6.1",


### PR DESCRIPTION
Otherwise this will cause conflicts with newer packages like coreshop relying on guzzle6-adapter ^2.0