### PR TITLE
[Mailchimp Sync] Delegate getActiveCustomerByEmail() to mailchimp newsletter handler and improve error handling

### DIFF
--- a/src/CustomerProvider/DefaultCustomerProvider.php
+++ b/src/CustomerProvider/DefaultCustomerProvider.php
@@ -15,6 +15,7 @@
 
 namespace CustomerManagementFrameworkBundle\CustomerProvider;
 
+use CustomerManagementFrameworkBundle\CustomerProvider\Exception\DuplicateCustomersFoundException;
 use CustomerManagementFrameworkBundle\CustomerProvider\ObjectNamingScheme\ObjectNamingSchemeInterface;
 use CustomerManagementFrameworkBundle\Model\CustomerInterface;
 use Pimcore\Model\DataObject\Concrete;
@@ -194,12 +195,11 @@ class DefaultCustomerProvider implements CustomerProviderInterface
     /**
      * Get active customer by email
      *
-     * @param int $id
-     * @param bool $foce
+     * @param string $email
      *
      * @return CustomerInterface|null
      *
-     * @throws \RuntimeException
+     * @throws DuplicateCustomersFoundException
      */
     public function getActiveCustomerByEmail($email)
     {
@@ -213,7 +213,7 @@ class DefaultCustomerProvider implements CustomerProviderInterface
         $list->addConditionParam('trim(email) like ?', [trim($email)]);
 
         if ($list->count() > 1) {
-            throw new \Exception(sprintf('multiple active and published customers with email %s found', $email));
+            throw new DuplicateCustomersFoundException(sprintf('multiple active and published customers with email %s found', $email));
         }
 
         return $list->current();

--- a/src/CustomerProvider/Exception/DuplicateCustomersFoundException.php
+++ b/src/CustomerProvider/Exception/DuplicateCustomersFoundException.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Pimcore
+ *
+ * This source file is available under two different licenses:
+ * - GNU General Public License version 3 (GPLv3)
+ * - Pimcore Enterprise License (PEL)
+ * Full copyright and license information is available in
+ * LICENSE.md which is distributed with this source code.
+ *
+ *  @copyright  Copyright (c) Pimcore GmbH (http://www.pimcore.org)
+ *  @license    http://www.pimcore.org/license     GPLv3 and PEL
+ */
+
+namespace CustomerManagementFrameworkBundle\CustomerProvider\Exception;
+
+class DuplicateCustomersFoundException extends \Exception {
+    
+}

--- a/src/Newsletter/ProviderHandler/Mailchimp.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp.php
@@ -820,11 +820,11 @@ class Mailchimp implements NewsletterProviderHandlerInterface
         if(!$email) {
             return false;
         }
-        /**
-         * @var CustomerProviderInterface $customerProvider
-         */
-        $customerProvider = \Pimcore::getContainer()->get(CustomerProviderInterface::class);
+
+        $customerProvider = $this->getCustomerProvider();
+
         $list = $customerProvider->getList();
+        $customerProvider->addActiveCondition($list);
         if($customerId) {
             $list->setCondition('trim(lower(email)) = ? and o_id != ?', [trim(strtolower($email)), $customerId]);
         } else {
@@ -839,5 +839,30 @@ class Mailchimp implements NewsletterProviderHandlerInterface
         }
 
         return false;
+    }
+
+    /**
+     * Override this method if you have multiple tenants
+     *
+     * @param string $email
+     * @return NewsletterAwareCustomerInterface
+     */
+    public function getActiveCustomerByEmail($email)
+    {
+        /**
+         * @var NewsletterAwareCustomerInterface $customer
+         */
+        $customer = $this->getCustomerProvider()->getActiveCustomerByEmail($email);
+        return $customer;
+    }
+
+    protected function getCustomerProvider(): CustomerProviderInterface
+    {
+        /**
+         * @var CustomerProviderInterface $customerProvider
+         */
+        $customerProvider = \Pimcore::getContainer()->get(CustomerProviderInterface::class);
+
+        return $customerProvider;
     }
 }

--- a/src/Newsletter/ProviderHandler/Mailchimp/CliSyncProcessor.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp/CliSyncProcessor.php
@@ -17,6 +17,7 @@ namespace CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp
 
 use Carbon\Carbon;
 use CustomerManagementFrameworkBundle\CustomerProvider\CustomerProviderInterface;
+use CustomerManagementFrameworkBundle\CustomerProvider\Exception\DuplicateCustomersFoundException;
 use CustomerManagementFrameworkBundle\Model\MailchimpAwareCustomerInterface;
 use CustomerManagementFrameworkBundle\Newsletter\Manager\NewsletterManagerInterface;
 use CustomerManagementFrameworkBundle\Newsletter\ProviderHandler\Mailchimp;
@@ -99,17 +100,20 @@ class CliSyncProcessor
                              * @var MailchimpAwareCustomerInterface $customer
                              */
                             try {
-                                if (!$customer = $this->customerProvider->getActiveCustomerByEmail(
+                                if (!$customer = $newsletterProviderHandler->getActiveCustomerByEmail(
                                     $row['email_address']
                                 )) {
                                     $this->getLogger()->error(
                                         sprintf('no active customer with email %s found', $row['email_address'])
                                     );
                                 }
-                            } catch (\Exception $e) {
+                            } catch (DuplicateCustomersFoundException $e) {
                                 $this->getLogger()->error(
                                     sprintf('multiple active customers with email %s found', $row['email_address'])
                                 );
+                                continue;
+                            } catch (\Exception $e) {
+                                $this->getLogger()->error($e->getMessage());
                                 continue;
                             }
 

--- a/src/Newsletter/ProviderHandler/Mailchimp/WebhookProcessor.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp/WebhookProcessor.php
@@ -49,7 +49,7 @@ class WebhookProcessor
         $logger->info($webhookData['data']['email']);
 
         try {
-            if (!$customer = $this->customerProvider->getActiveCustomerByEmail($webhookData['data']['email'])) {
+            if (!$customer = $mailchimpHandler->getActiveCustomerByEmail($webhookData['data']['email'])) {
                 $logger->error(sprintf('no active customer with email %s found', $webhookData['data']['email']));
 
                 return true;


### PR DESCRIPTION
This makes it possible to extend the logic for finding a customer by email address project and newsletter list specific.