### PR TITLE
SegmentAssigner Query Execution

### DIFF
--- a/src/SegmentAssignment/SegmentAssigner/SegmentAssigner.php
+++ b/src/SegmentAssignment/SegmentAssigner/SegmentAssigner.php
@@ -192,22 +192,27 @@ class SegmentAssigner implements SegmentAssignerInterface
 
         try {
             $deletePattern = 'DELETE FROM %s WHERE `elementId` = :elementId AND `elementType` = :elementType; ';
-
-            $statement = sprintf($deletePattern, $this->getSegmentAssignmentTable()) .
-                sprintf($deletePattern, $this->getSegmentAssignmentQueueTable()) .
-                sprintf($deletePattern, $this->getSegmentAssignmentIndexTable());
+            $tables = [
+                $this->getSegmentAssignmentTable(),
+                $this->getSegmentAssignmentQueueTable(),
+                $this->getSegmentAssignmentIndexTable(),
+            ];
 
             if (!$tActive) {
                 // start a new transaction
                 $db->beginTransaction();
             }
 
-            $this->getDb()->executeQuery($statement,
-                [
-                    'elementId' => $elementId,
-                    'elementType' => $type
-                ]
-            );
+            foreach ($tables as $table) {
+                $statement = sprintf($deletePattern, $table);
+
+                $this->getDb()->executeQuery($statement,
+                    [
+                        'elementId' => $elementId,
+                        'elementType' => $type
+                    ]
+                );
+            }
 
             if (!$tActive) {
                 $db->commit();


### PR DESCRIPTION
For some database configurations it is not possible to execute multiple queries at once.
Thus, this PR updated the `SegmentAssigner` class to execute the queries separately - which works for every DB.