### PR TITLE
Fix custom report adapter namespace as per psr-4 autoloading standards

### DIFF
--- a/src/CustomReport/Adapter/TermSegmentBuilder.php
+++ b/src/CustomReport/Adapter/TermSegmentBuilder.php
@@ -9,7 +9,7 @@
  * @license    GPLv3
  */
 
-namespace CustomerManagementFrameworkBundle\Adapter;
+namespace CustomerManagementFrameworkBundle\CustomReport\Adapter;
 
 use CustomerManagementFrameworkBundle\Model\AbstractTermSegmentBuilderDefinition;
 use Pimcore\Db;

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -241,7 +241,7 @@ services:
     cmf.custom_report.adapter.term_segment_builder:
         class: Pimcore\Model\Tool\CustomReport\Adapter\DefaultCustomReportAdapterFactory
         arguments:
-          - 'CustomerManagementFrameworkBundle\Adapter\TermSegmentBuilder'
+          - 'CustomerManagementFrameworkBundle\CustomReport\Adapter\TermSegmentBuilder'
 
     CustomerManagementFrameworkBundle\GDPR\DataProvider\Customers:
         public: false


### PR DESCRIPTION
```
Deprecation Notice: Class CustomerManagementFrameworkBundle\Adapter\TermSegmentBuilder located in ./vendor/pimcore/customer-management-framework-bundle/src/CustomReport/Adapter/TermSegmentBuilder.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///usr/local/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:185
```