### PR TITLE
Display the consent values as checkbox not as their class names.

### DIFF
--- a/src/View/Formatter/DefaultViewFormatter.php
+++ b/src/View/Formatter/DefaultViewFormatter.php
@@ -84,7 +84,7 @@ class DefaultViewFormatter implements ViewFormatterInterface
      */
     public function formatValueByFieldDefinition(Data $fd, $value)
     {
-        if ($fd instanceof Data\Checkbox) {
+        if ($fd instanceof Data\Checkbox || $fd instanceof Data\Consent) {
             return $this->formatBooleanValue($value);
         }
 


### PR DESCRIPTION
The consent values are shown with classnames not as checkboxes, provided in this screenshot
<img width="1659" alt="Bildschirmfoto 2020-04-16 um 20 07 19" src="https://user-images.githubusercontent.com/62768047/79491042-21a42080-801e-11ea-8b07-111cd1beedd1.png">

This implements the check to show checkboxes, fix applied shown below
<img width="1659" alt="Bildschirmfoto 2020-04-16 um 20 10 22" src="https://user-images.githubusercontent.com/62768047/79491183-5912cd00-801e-11ea-9969-b15a4c4a5744.png">
