### PR TITLE
clearAssignedTargetGroup null target group fix

### DIFF
--- a/src/Targeting/ActionHandler/ApplyTargetGroupsFromSegments.php
+++ b/src/Targeting/ActionHandler/ApplyTargetGroupsFromSegments.php
@@ -183,7 +183,9 @@ class ApplyTargetGroupsFromSegments implements ActionHandlerInterface, DataProvi
         foreach($consideredTargetGroupIds as $targetGroupId) {
             $targetGroup = TargetGroup::getById($targetGroupId);
             unset($storageData[$targetGroupId]);
-            $visitorInfo->clearAssignedTargetGroup($targetGroup);
+            if($targetGroup && $targetGroup->getActive()) {
+                $visitorInfo->clearAssignedTargetGroup($targetGroup);
+            }
         }
 
         foreach($targetGroupsToAssign as $targetGroupId => $count) {


### PR DESCRIPTION
In case the given target group is not found, the `clearAssignedTargetGroup` would fail with en error. Therefore simple test for target group presence.