### PR TITLE
Fix: Undefined index: duplicates_view

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -378,6 +378,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
 
                 ->arrayNode('duplicates_view')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('enabled')->defaultFalse()->end()
                         ->arrayNode('listFields')
@@ -391,6 +392,7 @@ class Configuration implements ConfigurationInterface
                 ->end()
 
                 ->arrayNode('duplicates_index')
+                    ->addDefaultsIfNotSet()
                     ->children()
                         ->booleanNode('enableDuplicatesIndex')
                             ->defaultFalse()


### PR DESCRIPTION
I get following notice with error reporting E_ALL:
```
Fatal error: Uncaught ErrorException: Notice: Undefined index: duplicates_view in vendor/pimcore/customer-management-framework-bundle/src/DependencyInjection/PimcoreCustomerManagementFrameworkExtension.php on line 134
```

The configs `duplicates_view`/`duplicates_index` havn't a default values.