### PR TITLE
CustomerTrait: return same type as pimcore-models

### DIFF
--- a/src/Model/Traits/CustomerTrait.php
+++ b/src/Model/Traits/CustomerTrait.php
@@ -61,13 +61,13 @@ trait CustomerTrait
         return [];
     }
 
-    public function getProfilingConsent()
+    public function getProfilingConsent(): ?\Pimcore\Model\DataObject\Data\Consent
     {
         if (is_callable('parent::getProfilingConsent')) {
             return parent::getProfilingConsent();
         }
 
-        return true;
+        return null;
     }
 
     /**
@@ -117,7 +117,7 @@ trait CustomerTrait
         return $this->getPublished() && $this->getActive();
     }
 
-    public function getCustomerLanguage()
+    public function getCustomerLanguage(): ?string
     {
         return null;
     }


### PR DESCRIPTION
getProfilingConsent() and getCustomerLanguage() -> return same type as pimcore-models or else there is a fatal error.

### How to reproduce
Pimcore 10.2.3

Add the CustomerTrait to your Customer-Object. You won't be able to open the folder your Customers are in because of an fatal error.