### PR TITLE
Fix deprecated required parameters after optional parameters in funct…

### DIFF
--- a/src/Newsletter/ProviderHandler/Mailchimp.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp.php
@@ -117,7 +117,7 @@ class Mailchimp implements NewsletterProviderHandlerInterface
      *
      * @throws \Exception
      */
-    public function __construct($shortcut, $listId, array $statusMapping = [], array $reverseStatusMapping = [], array $mergeFieldMapping = [], array $fieldTransformers = [], SegmentExporter $segmentExporter, SegmentManagerInterface $segmentManager, MailChimpExportService $exportService)
+    public function __construct($shortcut, $listId, array $statusMapping, array $reverseStatusMapping, array $mergeFieldMapping, array $fieldTransformers, SegmentExporter $segmentExporter, SegmentManagerInterface $segmentManager, MailChimpExportService $exportService)
     {
         if (!strlen($shortcut) || !File::getValidFilename($shortcut)) {
             throw new \Exception('Please provide a valid newsletter provider handler shortcut.');

--- a/src/Newsletter/ProviderHandler/Mailchimp/CliSyncProcessor.php
+++ b/src/Newsletter/ProviderHandler/Mailchimp/CliSyncProcessor.php
@@ -48,7 +48,7 @@ class CliSyncProcessor
      */
     protected $newsletterManager;
 
-    public function __construct($pimcoreUserName = null, CustomerProviderInterface $customerProvider, UpdateFromMailchimpProcessor $updateFromMailchimpProcessor, NewsletterManagerInterface $newsletterManager)
+    public function __construct($pimcoreUserName, CustomerProviderInterface $customerProvider, UpdateFromMailchimpProcessor $updateFromMailchimpProcessor, NewsletterManagerInterface $newsletterManager)
     {
         $this->setLoggerComponent('NewsletterSync');
 


### PR DESCRIPTION
Since PHP 8.0 the declaration of required parameter after optional parameters in a function is classified as deprecated. As a result, a deprecation notice is triggered at compile time - even if the affected method is not called. In an effort to prevent this compile error, the default values of the parameters are removed. Furthermore, there shouldn't be any issues concerning the backwards compability since all function calls are provided with the optional arguments before the required parameters are passed. 
However, since the default value is now missing, it has to be explicitly declared in the corresponding service. 

More information concerning this issue: 
https://php.watch/versions/8.0/deprecate-required-param-after-optional