### PR TITLE
CustomerInterface - Deprecate bool return type for getProfilingConsent

### DIFF
--- a/src/Model/CustomerInterface.php
+++ b/src/Model/CustomerInterface.php
@@ -211,9 +211,10 @@ interface CustomerInterface extends ElementInterface
     public function setIdEncoded(?string $idEncoded);
 
     /**
+     * Return type bool is deprecated and will be removed in version 4
      * @return Consent|bool|null
      */
-    public function getProfilingConsent();
+    public function getProfilingConsent() /* :?Consent */;
 
     /**
      * @return array

--- a/src/Model/CustomerInterface.php
+++ b/src/Model/CustomerInterface.php
@@ -212,6 +212,7 @@ interface CustomerInterface extends ElementInterface
 
     /**
      * Return type bool is deprecated and will be removed in version 4
+     *
      * @return Consent|bool|null
      */
     public function getProfilingConsent() /* :?Consent */;


### PR DESCRIPTION
All the implementations use more specific with return type `?\Pimcore\Model\DataObject\Data\Consent`