### PR TITLE
[Bug] Fix duplicate path check for object naming

### DIFF
--- a/src/Helper/Objects.php
+++ b/src/Helper/Objects.php
@@ -47,10 +47,16 @@ class Objects
         while ($notUnique) {
             $list = new \Pimcore\Model\DataObject\Listing;
             $list->setUnpublished(true);
-            $list->setCondition(
-                'o_path = ? and o_key = ? and o_id != ?',
-                [(string)$object->getParent() . '/', $object->getKey(), $object->getId()]
+            $list->addConditionParam(
+                'o_path = ? and o_key = ?',
+                [(string)$object->getParent() . '/', $object->getKey()]
             );
+            $objectId = $object->getId();
+            if ($objectId !== null) {
+                $list->addConditionParam('o_id != ?', $object->getId());
+            } else {
+                $list->addConditionParam('o_id is not null');
+            }
             $list->setLimit(1);
             $list = $list->load();
 


### PR DESCRIPTION
# Bugfix

This PR fixes the is not null check for newly created objects in the `::checkObjectKeyHelper()` method. Otherwise it will result in a duplicate fullpath error, if you would create a customer object with the same path/key naming as an already existing customer object.

### Expected Behaviour:
![image](https://user-images.githubusercontent.com/9052094/154647846-15c6e8eb-cbbf-4862-a562-347b904c3193.png)

### Current Behaviour:
> 'Duplicate full path xxx/xxx/xxx - cannot save object'

___
Also see https://dev.mysql.com/doc/refman/8.0/en/working-with-null.html