### PR TITLE
Fix: Call to an undefined method Exception::rollback()

### DIFF
--- a/src/ActivityStore/MariaDb.php
+++ b/src/ActivityStore/MariaDb.php
@@ -358,7 +358,7 @@ class MariaDb extends SqlActivityStore implements ActivityStoreInterface
 
             $db->commit();
         } catch (\Exception $e) {
-            $e->rollback();
+            $db->rollback();
 
             throw new $e;
         }


### PR DESCRIPTION
Noticed in #248
Fix for 3.2