### PR TITLE
Fix: Call to sprintf contains 2 placeholders, 3 values given.

### DIFF
--- a/src/CustomerSaveHandler/AttributeLogic.php
+++ b/src/CustomerSaveHandler/AttributeLogic.php
@@ -137,7 +137,7 @@ class AttributeLogic extends AbstractCustomerSaveHandler
 
         $this->getLogger()->debug(
             sprintf(
-                'overwrite field "%s" with field value from "%s" for customer ID ',
+                'overwrite field "%s" with field value from "%s" for customer ID %d',
                 $from,
                 $to,
                 $customer->getId()

--- a/src/CustomerSaveHandler/AttributeLogic.php
+++ b/src/CustomerSaveHandler/AttributeLogic.php
@@ -137,9 +137,9 @@ class AttributeLogic extends AbstractCustomerSaveHandler
 
         $this->getLogger()->debug(
             sprintf(
-                'overwrite field "%s" with field value from "%s" for customer ID %d',
-                $from,
+                'Overwrite field "%s" with field value from "%s" for customer ID %d',
                 $to,
+                $from,
                 $customer->getId()
             )
         );


### PR DESCRIPTION
Noticed in https://github.com/pimcore/customer-data-framework/pull/248
Fix for 3.2