### PR TITLE
Fix: Method DefaultEncryptionService::__sleep() should return array<int, string>

### DIFF
--- a/src/Encryption/DefaultEncryptionService.php
+++ b/src/Encryption/DefaultEncryptionService.php
@@ -117,14 +117,11 @@ class DefaultEncryptionService implements EncryptionServiceInterface
         return Crypto::decrypt($ciphertext, $key, $rawBinary);
     }
 
-    /**
-     * @return array|null
-     *
-     * @link http://php.net/manual/en/language.oop5.magic.php#language.oop5.magic.sleep
-     */
     public function __sleep()
     {
         // do not serialize default key
         $this->defaultKey = null;
+
+        return array_keys(get_object_vars($this));
     }
 }


### PR DESCRIPTION
Noticed in https://github.com/pimcore/customer-data-framework/pull/248
Fix for 3.2