### PR TITLE
Fix: Undefined methods addNewDataField/removeExistingDataField

### DIFF
--- a/src/Migrations/Version20171207150300.php
+++ b/src/Migrations/Version20171207150300.php
@@ -79,16 +79,16 @@ class Version20171207150300 extends AbstractPimcoreMigration
      * Adds given data field after existing field with given field name. If existing field is not found, nothing is added.
      *
      * @param ClassDefinition $class
-     * @param $fieldNameToAddAfter
+     * @param string $fieldNameToAddAfter
      * @param ClassDefinition\Data $fieldToAdd
      * @param ClassDefinition\Layout|null $layoutComponent
      */
     private function addNewDataField(
         ClassDefinition $class,
-        $fieldNameToAddAfter,
+        string $fieldNameToAddAfter,
         ClassDefinition\Data $fieldToAdd,
         ClassDefinition\Layout $layoutComponent = null
-    ) {
+    ): void {
         $found = false;
         $index = null;
         if (null === $layoutComponent) {

--- a/src/Migrations/Version20171218194028.php
+++ b/src/Migrations/Version20171218194028.php
@@ -78,7 +78,7 @@ class Version20171218194028 extends AbstractPimcoreMigration
         string $fieldNameToAddAfter,
         ClassDefinition\Data $fieldToAdd,
         ClassDefinition\Layout $layoutComponent = null
-    ) {
+    ): void {
         $found = false;
         $index = null;
         if (null === $layoutComponent) {


### PR DESCRIPTION
Noticed in https://github.com/pimcore/customer-data-framework/pull/248
Fix for 3.2

These methods are removed in Pimcore 6.0.0: https://github.com/pimcore/pimcore/commit/f53f49214889f4e3c925d88cf8fa868c80c04d97

Method addNewDataField is copied from https://github.com/pimcore/customer-data-framework/blob/3.2/src/Migrations/Version20171207150300.php