### PR TITLE
Fix: Undefined method migrateInstall

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
       "drewm/mailchimp-api": "*",
       "guzzlehttp/guzzle": ">=4.1.4 <8.0",
       "pear/archive_tar": "^1.4.3",
-      "pimcore/number-sequence-generator": "^1.0.1",
+      "pimcore/number-sequence-generator": "^1.0.5",
       "pimcore/object-merger": "^2.4 || ^3.0",
       "pimcore/pimcore": "^6.9 || ^10.0",
       "pimcore/search-query-parser": "^1.3",

--- a/src/Migrations/Version20171102160547.php
+++ b/src/Migrations/Version20171102160547.php
@@ -40,7 +40,7 @@ class Version20171102160547 extends AbstractPimcoreMigration
             $installer = \Pimcore::getContainer()->get(Installer::class);
 
             if (!$installer->isInstalled()) {
-                $installer->migrateInstall($schema, $this->version);
+                $installer->install();
             }
 
             if (!$installer->isInstalled()) {


### PR DESCRIPTION
Noticed in https://github.com/pimcore/customer-data-framework/pull/248
Fix for 3.2

These method was removed in number-sequence-generator 1.0.5: https://github.com/pimcore/number-sequence-generator/commit/89c85644fd6127dd13d08cd766757beb5a7e59ed