### PR TITLE
Fix deprecations in PimcoreCustomerManagementFrameworkBundle

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,11 +6,6 @@ parameters:
 			path: src/ActionTrigger/EventHandler/DefaultEventHandler.php
 
 		-
-			message: "#^Method CustomerManagementFrameworkBundle\\\\ActivityStore\\\\MySQL\\:\\:getActivityStoreConnection\\(\\) should return Doctrine\\\\DBAL\\\\Connection but returns Pimcore\\\\Db\\\\ConnectionInterface\\.$#"
-			count: 1
-			path: src/ActivityStore/MySQL.php
-
-		-
 			message: "#^Call to an undefined method Knp\\\\Component\\\\Pager\\\\Pagination\\\\PaginationInterface\\:\\:getPaginationData\\(\\)\\.$#"
 			count: 1
 			path: src/Controller/Admin/ActivitiesController.php

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -20,7 +20,6 @@ use CustomerManagementFrameworkBundle\Model\ActivityInterface;
 use CustomerManagementFrameworkBundle\Model\ActivityStoreEntry\ActivityStoreEntryInterface;
 use CustomerManagementFrameworkBundle\Model\CustomerInterface;
 use CustomerManagementFrameworkBundle\Traits\LoggerAware;
-use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Exception\TableNotFoundException;
 use Knp\Component\Pager\PaginatorInterface;
 use Pimcore\Db;
@@ -73,7 +72,7 @@ abstract class SqlActivityStore
     abstract protected function getAttributeInsertData(ActivityInterface $activity);
 
     /**
-     * @return Connection
+     * @return Db\ConnectionInterface
      */
     abstract protected function getActivityStoreConnection();
 

--- a/src/PimcoreCustomerManagementFrameworkBundle.php
+++ b/src/PimcoreCustomerManagementFrameworkBundle.php
@@ -32,7 +32,7 @@ class PimcoreCustomerManagementFrameworkBundle extends AbstractPimcoreBundle
         return 'pimcore/customer-management-framework-bundle';
     }
 
-    public function getJsPaths()
+    public function getJsPaths(): array
     {
         return [
             '/admin/customermanagementframework/helper/settings-json',
@@ -54,14 +54,14 @@ class PimcoreCustomerManagementFrameworkBundle extends AbstractPimcoreBundle
         ];
     }
 
-    public function getCssPaths()
+    public function getCssPaths(): array
     {
         return [
             '/bundles/pimcorecustomermanagementframework/css/pimcore.css',
         ];
     }
 
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new OAuthUtilsPass());
         $container->addCompilerPass(new CustomerSaveManagerPass());
@@ -69,7 +69,7 @@ class PimcoreCustomerManagementFrameworkBundle extends AbstractPimcoreBundle
         $container->addCompilerPass(new NewsletterManagerPass());
     }
 
-    public function getInstaller()
+    public function getInstaller(): Installer
     {
         return $this->container->get(Installer::class);
     }

--- a/tests/Model.suite.yml
+++ b/tests/Model.suite.yml
@@ -4,4 +4,5 @@ modules:
         - \CustomerManagementFrameworkBundle\Tests\Helper\Model
         - \Pimcore\Tests\Helper\Pimcore:
             connect_db: true
+            cache_router: false
         - \Pimcore\Tests\Helper\ClassManager


### PR DESCRIPTION
```
PHP Deprecated: Method "Pimcore\Extension\Bundle\PimcoreBundleInterface::getJsPaths()" might add "array" as a native return type declaration in the future. Do the same in implementation "CustomerManagementFrameworkBundle\PimcoreCustomerManagementFrameworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Pimcore\Extension\Bundle\PimcoreBundleInterface::getJsPaths()" might add "array" as a native return type declaration in the future. Do the same in implementation "CustomerManagementFrameworkBundle\PimcoreCustomerManagementFrameworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Pimcore\Extension\Bundle\PimcoreBundleInterface::getCssPaths()" might add "array" as a native return type declaration in the future. Do the same in implementation "CustomerManagementFrameworkBundle\PimcoreCustomerManagementFrameworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Pimcore\Extension\Bundle\PimcoreBundleInterface::getCssPaths()" might add "array" as a native return type declaration in the future. Do the same in implementation "CustomerManagementFrameworkBundle\PimcoreCustomerManagementFrameworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Pimcore\Extension\Bundle\PimcoreBundleInterface::getInstaller()" might add "?InstallerInterface" as a native return type declaration in the future. Do the same in implementation "CustomerManagementFrameworkBundle\PimcoreCustomerManagementFrameworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
PHP Deprecated: Method "Pimcore\Extension\Bundle\PimcoreBundleInterface::getInstaller()" might add "?InstallerInterface" as a native return type declaration in the future. Do the same in implementation "CustomerManagementFrameworkBundle\PimcoreCustomerManagementFrameworkBundle" now to avoid errors or add an explicit @return annotation to suppress this message. in /var/www/html/vendor/symfony/error-handler/DebugClassLoader.php on line 325
```