### PR TITLE
[UserProvider] OAuthAwareUserProvider - do not call deprecated method setUsername() in AccountNotLinkedException

### DIFF
--- a/src/Security/UserProvider/OAuthAwareUserProvider.php
+++ b/src/Security/UserProvider/OAuthAwareUserProvider.php
@@ -72,7 +72,6 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
                 $exception->setUserIdentifier($username);
             }
 
-
             throw $exception;
         }
 

--- a/src/Security/UserProvider/OAuthAwareUserProvider.php
+++ b/src/Security/UserProvider/OAuthAwareUserProvider.php
@@ -66,7 +66,7 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
                 $provider
             ));
 
-            $exception->setUsername($username);
+            $exception->setUserIdentifier($username);
 
             throw $exception;
         }

--- a/src/Security/UserProvider/OAuthAwareUserProvider.php
+++ b/src/Security/UserProvider/OAuthAwareUserProvider.php
@@ -66,7 +66,12 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
                 $provider
             ));
 
-            $exception->setUserIdentifier($username);
+            if (method_exists($exception, 'setUsername')) {
+                $exception->setUsername($username);
+            } else {
+                $exception->setUserIdentifier($username);
+            }
+
 
             throw $exception;
         }


### PR DESCRIPTION
Follow up to #281