### PR TITLE
Fix phpstan issue: ocramius/package-versions contains a Composer plug…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,10 @@
         "sort-packages": true,
         "preferred-install": {
           "pimcore/pimcore": "source"
-        }
+        },
+      "allow-plugins": {
+        "ocramius/package-versions": true
+      }
     },
     "require": {
       "box/spout": "^3.0",


### PR DESCRIPTION
```
Error: ocramius/package-versions contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.ocramius/package-versions [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins
In PluginManager.php line 769: ocramius/package-versions contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe  
  .                                                                            
  You can run "composer config --no-plugins allow-plugins.ocramius/package-ve  
  rsions [true|false]" to enable it (true) or disable it explicitly and suppr  
  ess this exception (false)                                                   
  See https://getcomposer.org/allow-plugins
```