### PR TITLE
Fix: RequestStack::getMasterRequest() is deprecated, use getMainRequest() instead.

### DIFF
--- a/src/CustomerSaveManager/DefaultCustomerSaveManager.php
+++ b/src/CustomerSaveManager/DefaultCustomerSaveManager.php
@@ -90,7 +90,7 @@ class DefaultCustomerSaveManager implements CustomerSaveManagerInterface
         if ($this->saveOptions->isObjectNamingSchemeEnabled()) {
             $this->customerProvider->applyObjectNamingScheme($customer);
 
-            $request = $this->requestStack->getMasterRequest();
+            $request = $this->requestStack->getMainRequest();
 
             //$this->setPimcoreContextResolver(\Pimcore::getContainer()->get('pimcore.service.request.pimcore_context_resolver'));
 
@@ -143,7 +143,7 @@ class DefaultCustomerSaveManager implements CustomerSaveManagerInterface
             $this->validateOnSave($customer);
         }
 
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
 
         //$this->setPimcoreContextResolver(\Pimcore::getContainer()->get('pimcore.service.request.pimcore_context_resolver'));
 

--- a/src/Twig/Extension/CmfUrlUtilsExtension.php
+++ b/src/Twig/Extension/CmfUrlUtilsExtension.php
@@ -88,7 +88,7 @@ class CmfUrlUtilsExtension extends AbstractExtension
             $formActionParams['perPage'] = $paginator->getItemNumberPerPage();
         }
 
-        $request = $this->requestStack->getMasterRequest();
+        $request = $this->requestStack->getMainRequest();
 
         return $this->router->generate($request->get('_route'), $formActionParams);
     }


### PR DESCRIPTION
```
DEPRECATION: Since symfony/http-foundation 5.3: "Symfony\Component\HttpFoundation\RequestStack::getMasterRequest()" is deprecated, use "getMainRequest()" instead.
```