### PR TITLE
OAuth (Github-)Login bugfix

### DIFF
--- a/src/Security/UserProvider/OAuthAwareUserProvider.php
+++ b/src/Security/UserProvider/OAuthAwareUserProvider.php
@@ -57,7 +57,7 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
             $username
         );
 
-        if (null === $user || '' === $username) {
+        if (is_null($user) || '' === $username) {
             // the AccountNotLinkedException will allow the frontend to proceed to registration
             // and to fetch user data from the OAuth account
             $exception = new AccountNotLinkedException(sprintf(

--- a/src/Security/UserProvider/OAuthAwareUserProvider.php
+++ b/src/Security/UserProvider/OAuthAwareUserProvider.php
@@ -67,7 +67,7 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
             ));
 
             if (method_exists($exception, 'setUsername')) {
-                $exception->setUsername($username);
+                $exception->setUsername((string)$username);
             }
 
             throw $exception;

--- a/src/Security/UserProvider/OAuthAwareUserProvider.php
+++ b/src/Security/UserProvider/OAuthAwareUserProvider.php
@@ -50,14 +50,14 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
     public function loadUserByOAuthUserResponse(UserResponseInterface $response)
     {
         $provider = $response->getResourceOwner()->getName();
-        $username = $response->getUsername();
+        $username = (string)$response->getUsername();
 
         $user = $this->ssoIdentityService->getCustomerBySsoIdentity(
             $provider,
             $username
         );
 
-        if (null === $user || null === $username) {
+        if (null === $user || '' === $username) {
             // the AccountNotLinkedException will allow the frontend to proceed to registration
             // and to fetch user data from the OAuth account
             $exception = new AccountNotLinkedException(sprintf(
@@ -67,7 +67,7 @@ class OAuthAwareUserProvider implements UserProviderInterface, OAuthAwareUserPro
             ));
 
             if (method_exists($exception, 'setUsername')) {
-                $exception->setUsername((string)$username);
+                $exception->setUsername($username);
             }
 
             throw $exception;


### PR DESCRIPTION
When using the Github OAuth login the $username variable is a int but it has to be a string, this fix converts it to a string.