### PR TITLE
Fixes the issue with the exact search in input filter

### DIFF
--- a/src/CustomerList/Filter/SearchQuery.php
+++ b/src/CustomerList/Filter/SearchQuery.php
@@ -59,7 +59,7 @@ class SearchQuery extends AbstractFilter implements OnCreateQueryFilterInterface
             if (strpos($this->query, '*') !== false) {
                 $queryBuilder->andWhere(sprintf('%s like %s', $this->fields[0], $listing->quote(str_replace('*', '%', $this->query))));
             } else {
-                $queryBuilder->andWhere (sprintf ('%s = %s', $this->fields[0], $listing->quote (preg_replace ('/^"(.*)"$/', '$1', $this->query))));
+                $queryBuilder->andWhere(sprintf('%s = %s', $this->fields[0], $listing->quote(preg_replace('/^"(.*)"$/', '$1', $this->query))));
             }
 
             return;

--- a/src/CustomerList/Filter/SearchQuery.php
+++ b/src/CustomerList/Filter/SearchQuery.php
@@ -59,7 +59,7 @@ class SearchQuery extends AbstractFilter implements OnCreateQueryFilterInterface
             if (strpos($this->query, '*') !== false) {
                 $queryBuilder->andWhere(sprintf('%s like %s', $this->fields[0], $listing->quote(str_replace('*', '%', $this->query))));
             } else {
-                $queryBuilder->andWhere(sprintf('%s = %s', $this->fields[0], $listing->quote($this->query)));
+                $queryBuilder->andWhere (sprintf ('%s = %s', $this->fields[0], $listing->quote (preg_replace ('/^"(.*)"$/', '$1', $this->query))));
             }
 
             return;


### PR DESCRIPTION
Fixes the issue with exact modifier search. For eg: if you search "Fred" in the `Firstname` input filter, then it returns nothing because the doublequotes get escaped into '\"Fred\"'. 
