### PR TITLE
Add wildcard filter doc in the help section

### DIFF
--- a/src/Resources/views/admin/partial/list_filter_helper.html.twig
+++ b/src/Resources/views/admin/partial/list_filter_helper.html.twig
@@ -1,5 +1,7 @@
 
 {% set exampleQueries = [
+    'fo* OR bar',
+    '*a* AND foo',
     'foo',
     'foo AND bar',
     'foo OR bar',
@@ -10,6 +12,9 @@
 %}
 
 {% set modifiers = {
+    'Wildcard search (searched pattern should match the field/subpart of the field))': [
+        '<term>*',
+    ],
     'Exact search (field must match exactly)': [
         '"<term>"',
     ],


### PR DESCRIPTION
Resolves #234 

We cannot make  the search input filter as wildcard search by default. Because, it is not the right way according to the SearchQueryParser implementation. So, added the wildcard doc in the help section.