### PR TITLE
Fix DefaultStoredFunctions::retrieve()

### DIFF
--- a/src/SegmentAssignment/StoredFunctions/DefaultStoredFunctions.php
+++ b/src/SegmentAssignment/StoredFunctions/DefaultStoredFunctions.php
@@ -29,6 +29,6 @@ class DefaultStoredFunctions implements StoredFunctionsInterface
     {
         $storedFunction = static::STORED_FUNCTIONS_MAPPING[$elementType];
 
-        return explode(',', Db::get()->fetchFirstColumn("SELECT $storedFunction(:elementId)", ['elementId' => $elementId | 0]));
+        return explode(',', Db::get()->fetchOne("SELECT $storedFunction(:elementId)", ['elementId' => $elementId | 0]));
     }
 }


### PR DESCRIPTION
See https://github.com/pimcore/customer-data-framework/pull/320#issuecomment-1232802878

fetchFirstColumn is the replacement for fetchCol
fetchOne is the replacement for fetchColumn