### PR TITLE
Avoid usage of deprecated service aliases

### DIFF
--- a/install/class_source/class_LinkActivityDefinition_export.json
+++ b/install/class_source/class_LinkActivityDefinition_export.json
@@ -514,7 +514,7 @@
     "previewUrl": "\/__customermanagementframework\/object-preview\/link-activity-definition-preview",
     "group": "CustomerManagement",
     "showAppLoggerTab": false,
-    "linkGeneratorReference": "@cmf.link-activity-definition.linkgenerator",
+    "linkGeneratorReference": "@CustomerManagementFrameworkBundle\\LinkGenerator\\LinkActivityDefinitionLinkGenerator",
     "compositeIndices": [],
     "showFieldLookup": false,
     "propertyVisibility": {

--- a/src/Maintenance/Tasks/CleanupExportTmpDataTask.php
+++ b/src/Maintenance/Tasks/CleanupExportTmpDataTask.php
@@ -15,12 +15,17 @@
 
 namespace CustomerManagementFrameworkBundle\Maintenance\Tasks;
 
+use CustomerManagementFrameworkBundle\CustomerList\ExporterManagerInterface;
 use Pimcore\Maintenance\TaskInterface;
 
 class CleanupExportTmpDataTask implements TaskInterface
 {
+    public function __construct(private ExporterManagerInterface $exporterManager)
+    {
+    }
+
     public function execute(): void
     {
-        \Pimcore::getContainer()->get('cmf.customer_exporter_manager')->cleanupExportTmpData();
+        $this->exporterManager->cleanupExportTmpData();
     }
 }

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -160,16 +160,15 @@ services:
         class: CustomerManagementFrameworkBundle\ActivityUrlTracker\DefaultActivityUrlTracker
 
     CustomerManagementFrameworkBundle\LinkGenerator\LinkActivityDefinitionLinkGenerator:
-        alias: cmf.link-activity-definition.linkgenerator
+        arguments:
+            - '%pimcore_customer_management_framework.url_activity_tracker.linkCmfcPlaceholder%'
 
     cmf.link-activity-definition.linkgenerator:
-        class: CustomerManagementFrameworkBundle\LinkGenerator\LinkActivityDefinitionLinkGenerator
+        alias: CustomerManagementFrameworkBundle\LinkGenerator\LinkActivityDefinitionLinkGenerator
         deprecated:
-            message: 'The "%service_id%" service is deprecated. Use "CustomerManagementFrameworkBundle\LinkGenerator\LinkActivityDefinitionLinkGenerator" instead'
+            message: 'The "%alias_id%" alias is deprecated. Use "CustomerManagementFrameworkBundle\LinkGenerator\LinkActivityDefinitionLinkGenerator" instead'
             package: pimcore/customer-management-framework-bundle
             version: 3.0
-        arguments:
-          - '%pimcore_customer_management_framework.url_activity_tracker.linkCmfcPlaceholder%'
 
     cmf.segment_manager.segment_merger:
         class: CustomerManagementFrameworkBundle\SegmentManager\SegmentMerger\DefaultSegmentMerger
@@ -202,25 +201,25 @@ services:
 
 
     CustomerManagementFrameworkBundle\CustomerList\ExporterManagerInterface:
-        alias: cmf.customer_exporter_manager
+        class: CustomerManagementFrameworkBundle\CustomerList\ExporterManager
+        arguments:
+            - '%pimcore_customer_management_framework.customer_list.exporters%'
 
     cmf.customer_exporter_manager:
-         class: CustomerManagementFrameworkBundle\CustomerList\ExporterManager
+         alias: CustomerManagementFrameworkBundle\CustomerList\ExporterManagerInterface
          deprecated:
-             message: 'The "%service_id%" service is deprecated. Use "CustomerManagementFrameworkBundle\CustomerList\ExporterManagerInterface" instead'
+             message: 'The "%alias_id%" alias is deprecated. Use "CustomerManagementFrameworkBundle\CustomerList\ExporterManagerInterface" instead'
              package: pimcore/customer-management-framework-bundle
              version: 3.0
-         arguments:
-              - '%pimcore_customer_management_framework.customer_list.exporters%'
 
 
     CustomerManagementFrameworkBundle\ActionTrigger\Queue\QueueInterface:
-        alias: cmf.action_trigger.queue
+        class: CustomerManagementFrameworkBundle\ActionTrigger\Queue\DefaultQueue
 
     cmf.action_trigger.queue:
-        class: CustomerManagementFrameworkBundle\ActionTrigger\Queue\DefaultQueue
+        alias: CustomerManagementFrameworkBundle\ActionTrigger\Queue\QueueInterface
         deprecated:
-            message: 'The "%service_id%" service is deprecated. Use "CustomerManagementFrameworkBundle\ActionTrigger\Queue\QueueInterface" instead'
+            message: 'The "%alias_id%" alias is deprecated. Use "CustomerManagementFrameworkBundle\ActionTrigger\Queue\QueueInterface" instead'
             package: pimcore/customer-management-framework-bundle
             version: 3.0
 

--- a/src/Resources/config/services_events.yml
+++ b/src/Resources/config/services_events.yml
@@ -1,50 +1,50 @@
 services:
     _defaults:
-            public: true
-            autowire: true
-            autoconfigure: true
+        public: true
+        autowire: true
+        autoconfigure: true
 
     pimcore.event_listener.frontend.activity_url_tracker:
-            class: CustomerManagementFrameworkBundle\Event\Frontend\UrlActivityTracker
-            tags:
-                - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: -200 }
+        class: CustomerManagementFrameworkBundle\Event\Frontend\UrlActivityTracker
+        tags:
+            - { name: kernel.event_listener, event: kernel.request, method: onKernelRequest, priority: -200 }
 
 
     cmf.event_listener.pimcore_object:
-       class: CustomerManagementFrameworkBundle\Event\PimcoreObjectEventListener
-       tags:
-           - { name: kernel.event_listener, event: pimcore.dataobject.preUpdate, method: onPreUpdate }
-           - { name: kernel.event_listener, event: pimcore.dataobject.postUpdate, method: onPostUpdate }
-           - { name: kernel.event_listener, event: pimcore.dataobject.preAdd, method: onPreAdd }
-           - { name: kernel.event_listener, event: pimcore.dataobject.postAdd, method: onPostAdd }
-           - { name: kernel.event_listener, event: pimcore.dataobject.preDelete, method: onPreDelete }
-           - { name: kernel.event_listener, event: pimcore.dataobject.postDelete, method: onPostDelete }
-           - { name: kernel.event_listener, event: pimcore.dataobject.import.preSave, method: onPreSave }
+        class: CustomerManagementFrameworkBundle\Event\PimcoreObjectEventListener
+        tags:
+            - { name: kernel.event_listener, event: pimcore.dataobject.preUpdate, method: onPreUpdate }
+            - { name: kernel.event_listener, event: pimcore.dataobject.postUpdate, method: onPostUpdate }
+            - { name: kernel.event_listener, event: pimcore.dataobject.preAdd, method: onPreAdd }
+            - { name: kernel.event_listener, event: pimcore.dataobject.postAdd, method: onPostAdd }
+            - { name: kernel.event_listener, event: pimcore.dataobject.preDelete, method: onPreDelete }
+            - { name: kernel.event_listener, event: pimcore.dataobject.postDelete, method: onPostDelete }
+            - { name: kernel.event_listener, event: pimcore.dataobject.import.preSave, method: onPreSave }
 
     cmf.event_listener.object_merger:
-           class: CustomerManagementFrameworkBundle\Event\CustomerMergerEventListener
-           tags:
-               - { name: kernel.event_listener, event: plugin.ObjectMerger.postMerge, method: onPostMerge }
-               - { name: kernel.event_listener, event: plugin.ObjectMerger.preMerge, method: onPreMerge }
+        class: CustomerManagementFrameworkBundle\Event\CustomerMergerEventListener
+        tags:
+            - { name: kernel.event_listener, event: plugin.ObjectMerger.postMerge, method: onPostMerge }
+            - { name: kernel.event_listener, event: plugin.ObjectMerger.preMerge, method: onPreMerge }
 
     CustomerManagementFrameworkBundle\ActionTrigger\EventHandler\EventHandlerInterface:
-        alias: cmf.event_listener.action_trigger
-
-    cmf.event_listener.action_trigger:
         class: CustomerManagementFrameworkBundle\ActionTrigger\EventHandler\DefaultEventHandler
-        deprecated:
-            message: 'The "%service_id%" service is deprecated. Use "CustomerManagementFrameworkBundle\ActionTrigger\Queue\QueueInterface" instead'
-            package: pimcore/customer-management-framework-bundle
-            version: 3.0
         tags:
             - { name: kernel.event_listener, event: plugin.cmf.new-activity, method: handleEvent }
             - { name: kernel.event_listener, event: plugin.cmf.execute-segment-builders, method: handleEvent }
             - { name: kernel.event_listener, event: plugin.cmf.after-track-activity, method: handleEvent }
             - { name: kernel.event_listener, event: plugin.cmf.segment-tracked, method: handleEvent }
             - { name: kernel.event_listener, event: plugin.cmf.target-group-assigned, method: handleEvent }
-
         calls:
             - [setLogger, ['@cmf.logger']]
+
+    cmf.event_listener.action_trigger:
+        alias: CustomerManagementFrameworkBundle\ActionTrigger\EventHandler\EventHandlerInterface
+        deprecated:
+            message: 'The "%alias_id%" alias is deprecated. Use "CustomerManagementFrameworkBundle\ActionTrigger\EventHandler\EventHandlerInterface" instead'
+            package: pimcore/customer-management-framework-bundle
+            version: 3.0
+
 
     CustomerManagementFrameworkBundle\Event\PimcoreElementRemovalListenerInterface:
         class: CustomerManagementFrameworkBundle\Event\PimcoreElementRemovalListener


### PR DESCRIPTION
Every system with this bundle logs many deprecations because of usage of the deprecated service aliases. Should be replaced with the correct service.