### PR TITLE
Codeception/Symfony: Fix deprecations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -191,11 +191,6 @@ parameters:
 			path: src/Security/SsoIdentity/DefaultSsoIdentityService.php
 
 		-
-			message: "#^Method CustomerManagementFrameworkBundle\\\\Security\\\\UserProvider\\\\CustomerObjectUserProvider\\:\\:refreshUser\\(\\) should return Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface but returns CustomerManagementFrameworkBundle\\\\Model\\\\CustomerInterface\\|null\\.$#"
-			count: 1
-			path: src/Security/UserProvider/CustomerObjectUserProvider.php
-
-		-
 			message: "#^Binary operation \"\\|\" between string and 0 results in an error\\.$#"
 			count: 1
 			path: src/SegmentAssignment/StoredFunctions/DefaultStoredFunctions.php

--- a/src/Command/ActionTriggerQueueCommand.php
+++ b/src/Command/ActionTriggerQueueCommand.php
@@ -49,8 +49,10 @@ class ActionTriggerQueueCommand extends AbstractCommand
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)//: int
     {
         $this->lock(self::LOCK_KEY);
 

--- a/src/Command/BuildSegmentsCommand.php
+++ b/src/Command/BuildSegmentsCommand.php
@@ -81,8 +81,10 @@ class BuildSegmentsCommand extends AbstractCommand
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)//: int
     {
         $customQueue = null;
         if ($input->getOption('customer')) {

--- a/src/Command/CronTriggerCommand.php
+++ b/src/Command/CronTriggerCommand.php
@@ -45,8 +45,10 @@ class CronTriggerCommand extends AbstractCommand
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)//: int
     {
         $logger = $this->getLogger();
 

--- a/src/Command/DuplicatesIndexCommand.php
+++ b/src/Command/DuplicatesIndexCommand.php
@@ -47,8 +47,10 @@ class DuplicatesIndexCommand extends AbstractCommand
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
+     *
+     * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)//: int
     {
         $logger = $this->getLogger();
 

--- a/src/Command/MaintenanceCommand.php
+++ b/src/Command/MaintenanceCommand.php
@@ -51,7 +51,7 @@ class MaintenanceCommand extends AbstractCommand
      *
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output)//: int
     {
         $this->maintenanceWorker->execute();
 

--- a/src/Command/SegmentAssignmentIndexCommand.php
+++ b/src/Command/SegmentAssignmentIndexCommand.php
@@ -41,7 +41,13 @@ class SegmentAssignmentIndexCommand extends AbstractCommand
             ->setDescription('Processes entries from segment assignment queue, use this for manually updating the index, which is usually done during cmf:maintenance');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    /**
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     *
+     * @return int
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)//: int
     {
         $this->indexer->processQueue();
 

--- a/src/Controller/Rest/AbstractRestController.php
+++ b/src/Controller/Rest/AbstractRestController.php
@@ -34,8 +34,10 @@ abstract class AbstractRestController extends AdminController
 
     /**
      * @inheritDoc
+     *
+     * @return bool
      */
-    public function needsSessionDoubleAuthenticationCheck()
+    public function needsSessionDoubleAuthenticationCheck()//: bool
     {
         // do not double-check session as api key auth is possible
         return false;

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -23,7 +23,10 @@ use Symfony\Component\Config\Definition\ConfigurationInterface;
 
 class Configuration implements ConfigurationInterface
 {
-    public function getConfigTreeBuilder()
+    /**
+     * @return TreeBuilder
+     */
+    public function getConfigTreeBuilder()//: TreeBuilder
     {
         $treeBuilder = new TreeBuilder('pimcore_customer_management_framework');
         $rootNode = $treeBuilder->getRootNode();

--- a/src/Event/Frontend/UrlActivityTracker.php
+++ b/src/Event/Frontend/UrlActivityTracker.php
@@ -28,8 +28,10 @@ class UrlActivityTracker implements EventSubscriberInterface
 
     /**
      * @inheritDoc
+     *
+     * @return array<string, string>
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents()//: array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/Installer.php
+++ b/src/Installer.php
@@ -44,8 +44,10 @@ class Installer extends SettingsStoreAwareInstaller
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
-    public function needsReloadAfterInstall()
+    public function needsReloadAfterInstall()//: bool
     {
         return true;
     }

--- a/src/Model/ActionTrigger/Rule/Listing.php
+++ b/src/Model/ActionTrigger/Rule/Listing.php
@@ -23,7 +23,12 @@ use Pimcore\Model\Listing\AbstractListing;
  */
 class Listing extends AbstractListing
 {
-    public function isValidOrderKey($key)
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function isValidOrderKey(/* string */ $key)//: bool
     {
         return true;
     }
@@ -31,7 +36,7 @@ class Listing extends AbstractListing
     /**
      * @return Rule[]
      */
-    public function load()
+    public function load()//: array
     {
         return $this->getDao()->load();
     }

--- a/src/Model/ActionTrigger/Rule/Listing/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Listing/Dao.php
@@ -20,7 +20,10 @@ use Pimcore\Model;
 
 class Dao extends Model\Listing\Dao\AbstractDao
 {
-    public function load()
+    /**
+     * @return array
+     */
+    public function load()//: array
     {
         $rules = [];
 
@@ -39,7 +42,7 @@ class Dao extends Model\Listing\Dao\AbstractDao
     /**
      * @return int
      */
-    public function getTotalCount()
+    public function getTotalCount()//: int
     {
         return (int)$this->db->fetchOne(
             'SELECT COUNT(*) as amount FROM '.Rule\Dao::TABLE_NAME.' '.$this->getCondition(),

--- a/src/Model/ActionTrigger/Rule/Listing/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Listing/Dao.php
@@ -21,7 +21,7 @@ use Pimcore\Model;
 class Dao extends Model\Listing\Dao\AbstractDao
 {
     /**
-     * @return array
+     * @return Rule[]
      */
     public function load()//: array
     {

--- a/src/Model/ActivityList/DefaultMariaDbActivityList.php
+++ b/src/Model/ActivityList/DefaultMariaDbActivityList.php
@@ -17,6 +17,7 @@ namespace CustomerManagementFrameworkBundle\Model\ActivityList;
 
 use CustomerManagementFrameworkBundle\Model\ActivityInterface;
 use CustomerManagementFrameworkBundle\Model\ActivityList\DefaultMariaDbActivityList\MariaDbDao;
+use CustomerManagementFrameworkBundle\Model\ActivityStoreEntry\ActivityStoreEntryInterface;
 use Pimcore\Model\Listing\AbstractListing;
 
 class DefaultMariaDbActivityList extends AbstractListing implements ActivityListInterface
@@ -198,7 +199,7 @@ class DefaultMariaDbActivityList extends AbstractListing implements ActivityList
     }
 
     /**
-     * @return array
+     * @return ActivityStoreEntryInterface[]
      */
     public function load()//: array
     {

--- a/src/Model/ActivityList/DefaultMariaDbActivityList.php
+++ b/src/Model/ActivityList/DefaultMariaDbActivityList.php
@@ -197,7 +197,10 @@ class DefaultMariaDbActivityList extends AbstractListing implements ActivityList
         reset($this->activities);
     }
 
-    public function load()
+    /**
+     * @return array
+     */
+    public function load()//: array
     {
         $raw = $this->dao->load();
 
@@ -214,7 +217,12 @@ class DefaultMariaDbActivityList extends AbstractListing implements ActivityList
         return $activities;
     }
 
-    public function isValidOrderKey($key)
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function isValidOrderKey(/* string */ $key)//: bool
     {
         return true;
     }

--- a/src/Model/CustomerInterface.php
+++ b/src/Model/CustomerInterface.php
@@ -39,19 +39,19 @@ interface CustomerInterface extends ElementInterface
     public function getPublished();
 
     /**
-     * @return bool
+     * @return bool|null
      */
     public function getActive(): ?bool;
 
     /**
-     * @param bool $active
+     * @param bool|null $active
      *
      * @return void
      */
     public function setActive(?bool $active);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getGender(): ?string;
 
@@ -63,7 +63,7 @@ interface CustomerInterface extends ElementInterface
     public function setGender(?string $gender);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFirstname(): ?string;
 
@@ -75,7 +75,7 @@ interface CustomerInterface extends ElementInterface
     public function setFirstname(?string $firstname);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getLastname(): ?string;
 
@@ -87,7 +87,7 @@ interface CustomerInterface extends ElementInterface
     public function setLastname(?string $lastname);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getStreet(): ?string;
 
@@ -99,7 +99,7 @@ interface CustomerInterface extends ElementInterface
     public function setStreet(?string $street);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getZip(): ?string;
 
@@ -111,7 +111,7 @@ interface CustomerInterface extends ElementInterface
     public function setZip(?string $zip);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCity(): ?string;
 
@@ -123,7 +123,7 @@ interface CustomerInterface extends ElementInterface
     public function setCity(?string $city);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getCountryCode(): ?string;
 
@@ -135,7 +135,7 @@ interface CustomerInterface extends ElementInterface
     public function setCountryCode(?string $countryCode);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getEmail(): ?string;
 
@@ -147,7 +147,7 @@ interface CustomerInterface extends ElementInterface
     public function setEmail(?string $email);
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getPhone(): ?string;
 
@@ -193,7 +193,7 @@ interface CustomerInterface extends ElementInterface
     public function getAllSegments();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getIdEncoded(): ?string;
 

--- a/src/Model/CustomerView/FilterDefinition/Listing.php
+++ b/src/Model/CustomerView/FilterDefinition/Listing.php
@@ -55,7 +55,12 @@ class Listing extends Model\Listing\AbstractListing
         return $this;
     }
 
-    public function isValidOrderKey($key)
+    /**
+     * @param string $key
+     *
+     * @return bool
+     */
+    public function isValidOrderKey(/* string */ $key)//: bool
     {
         return $key != 'definition';
     }

--- a/src/Newsletter/Queue/DefaultNewsletterQueue.php
+++ b/src/Newsletter/Queue/DefaultNewsletterQueue.php
@@ -203,9 +203,6 @@ class DefaultNewsletterQueue implements NewsletterQueueInterface
      */
     protected function processAllItems(array $newsletterProviderHandlers, $forceUpdate)
     {
-        /**
-         * @var CustomerProviderInterface
-         */
         $customerProvider = \Pimcore::getContainer()->get('cmf.customer_provider');
 
         $list = $customerProvider->getList();
@@ -346,9 +343,6 @@ class DefaultNewsletterQueue implements NewsletterQueueInterface
      */
     protected function createItemFromData(array $data)
     {
-        /**
-         * @var CustomerProviderInterface
-         */
         $customerProvider = \Pimcore::getContainer()->get('cmf.customer_provider');
 
         $customer = $customerProvider->getById($data['customerId']);

--- a/src/Security/Guard/WebserviceAuthenticator.php
+++ b/src/Security/Guard/WebserviceAuthenticator.php
@@ -21,10 +21,10 @@ use Pimcore\Bundle\AdminBundle\Security\User\User as UserProxy;
 use Pimcore\Model\Tool\SettingsStore;
 use Pimcore\Model\User;
 use Pimcore\Tool\Authentication;
-use Pimcore\Tool\Session;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerAwareTrait;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\AccessDeniedHttpException;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -41,24 +41,30 @@ class WebserviceAuthenticator extends AbstractGuardAuthenticator implements Logg
 
     /**
      * {@inheritdoc}
+     *
+     * @return bool
      */
-    public function supports(Request $request)
+    public function supports(Request $request)//: bool
     {
         return true;
     }
 
     /**
      * @inheritDoc
+     *
+     * @return Response
      */
-    public function start(Request $request, AuthenticationException $authException = null)
+    public function start(Request $request, AuthenticationException $authException = null)//: Response
     {
         throw $this->createAccessDeniedException($authException);
     }
 
     /**
      * @inheritDoc
+     *
+     * @return array
      */
-    public function getCredentials(Request $request)
+    public function getCredentials(Request $request)//: array
     {
         if ($apiKey = $request->headers->get('x_api-key')) {
             // check for API key header
@@ -89,8 +95,10 @@ class WebserviceAuthenticator extends AbstractGuardAuthenticator implements Logg
 
     /**
      * @inheritDoc
+     *
+     * @return UserInterface|null
      */
-    public function getUser($credentials, UserProviderInterface $userProvider)
+    public function getUser($credentials, UserProviderInterface $userProvider)//: ?UserInterface
     {
         /** @var UserProxy|null $user */
         $user = null;
@@ -139,8 +147,10 @@ class WebserviceAuthenticator extends AbstractGuardAuthenticator implements Logg
 
     /**
      * @inheritDoc
+     *
+     * @return bool
      */
-    public function checkCredentials($credentials, UserInterface $user)
+    public function checkCredentials($credentials, UserInterface $user)//: bool
     {
         // we rely on getUser returning a valid user
         if ($user instanceof UserProxy) {
@@ -152,8 +162,10 @@ class WebserviceAuthenticator extends AbstractGuardAuthenticator implements Logg
 
     /**
      * @inheritDoc
+     *
+     * @return Response|null
      */
-    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)//: ?Response
     {
         $this->logger->warning('Failed to authenticate for webservice request {path}', [
             'path' => $request->getPathInfo(),
@@ -164,8 +176,10 @@ class WebserviceAuthenticator extends AbstractGuardAuthenticator implements Logg
 
     /**
      * @inheritDoc
+     *
+     * @return Response|null
      */
-    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)//: ?Response
     {
         $this->logger->debug('Successfully authenticated user {user} for webservice request {path}', [
             'user' => $token->getUser()->getUsername(),
@@ -177,8 +191,10 @@ class WebserviceAuthenticator extends AbstractGuardAuthenticator implements Logg
 
     /**
      * @inheritDoc
+     *
+     * @return bool
      */
-    public function supportsRememberMe()
+    public function supportsRememberMe()//: bool
     {
         return false;
     }

--- a/src/Security/UserProvider/CustomerObjectUserProvider.php
+++ b/src/Security/UserProvider/CustomerObjectUserProvider.php
@@ -46,9 +46,9 @@ class CustomerObjectUserProvider implements UserProviderInterface
     /**
      * @inheritdoc
      *
-     * @return CustomerInterface
+     * @return UserInterface
      */
-    public function loadUserByIdentifier(string $identifier)//: CustomerInterface
+    public function loadUserByIdentifier(string $identifier)//: UserInterface
     {
         $list = $this->customerProvider->getList();
         $list->setCondition(sprintf('%s = ?', $this->usernameField), $identifier);
@@ -57,7 +57,7 @@ class CustomerObjectUserProvider implements UserProviderInterface
         /** @var CustomerInterface|false $customer */
         $customer = $list->current();
 
-        if (!$customer) {
+        if (!$customer instanceof UserInterface) {
             throw new UserNotFoundException(sprintf('Customer "%s" was not found', $identifier));
         }
 
@@ -77,16 +77,22 @@ class CustomerObjectUserProvider implements UserProviderInterface
     /**
      * @inheritdoc
      *
-     * @return CustomerInterface
+     * @return UserInterface
      */
-    public function refreshUser(UserInterface $user)//: CustomerInterface
+    public function refreshUser(UserInterface $user)//: UserInterface
     {
         $class = $this->customerProvider->getCustomerClassName();
         if (!$user instanceof $class || !$user instanceof AbstractObject) {
             throw new UnsupportedUserException();
         }
 
-        return $this->customerProvider->getById($user->getId(), true);
+        $customer = $this->customerProvider->getById($user->getId(), true);
+
+        if (!$customer instanceof UserInterface) {
+            throw new UserNotFoundException(sprintf('Customer "%s" was not found', $user->getId()));
+        }
+
+        return $customer;
     }
 
     /**
@@ -96,10 +102,6 @@ class CustomerObjectUserProvider implements UserProviderInterface
      */
     public function supportsClass($class)//: bool
     {
-        if ($class === $this->customerProvider->getCustomerClassName()) {
-            return true;
-        }
-
-        return false;
+        return $class === $this->customerProvider->getCustomerClassName();
     }
 }

--- a/src/Security/UserProvider/CustomerObjectUserProvider.php
+++ b/src/Security/UserProvider/CustomerObjectUserProvider.php
@@ -79,7 +79,7 @@ class CustomerObjectUserProvider implements UserProviderInterface
      *
      * @return UserInterface
      */
-    public function refreshUser(UserInterface $user)//: UserInterface
+    public function refreshUser(UserInterface $user)
     {
         $class = $this->customerProvider->getCustomerClassName();
         if (!$user instanceof $class || !$user instanceof AbstractObject) {
@@ -100,7 +100,7 @@ class CustomerObjectUserProvider implements UserProviderInterface
      *
      * @return bool
      */
-    public function supportsClass($class)//: bool
+    public function supportsClass($class)
     {
         return $class === $this->customerProvider->getCustomerClassName();
     }

--- a/src/Security/UserProvider/CustomerObjectUserProvider.php
+++ b/src/Security/UserProvider/CustomerObjectUserProvider.php
@@ -45,8 +45,10 @@ class CustomerObjectUserProvider implements UserProviderInterface
 
     /**
      * @inheritdoc
+     *
+     * @return CustomerInterface
      */
-    public function loadUserByIdentifier(string $identifier)
+    public function loadUserByIdentifier(string $identifier)//: CustomerInterface
     {
         $list = $this->customerProvider->getList();
         $list->setCondition(sprintf('%s = ?', $this->usernameField), $identifier);
@@ -74,8 +76,10 @@ class CustomerObjectUserProvider implements UserProviderInterface
 
     /**
      * @inheritdoc
+     *
+     * @return CustomerInterface
      */
-    public function refreshUser(UserInterface $user)
+    public function refreshUser(UserInterface $user)//: CustomerInterface
     {
         $class = $this->customerProvider->getCustomerClassName();
         if (!$user instanceof $class || !$user instanceof AbstractObject) {
@@ -87,8 +91,10 @@ class CustomerObjectUserProvider implements UserProviderInterface
 
     /**
      * @inheritdoc
+     *
+     * @return bool
      */
-    public function supportsClass($class)
+    public function supportsClass($class)//: bool
     {
         if ($class === $this->customerProvider->getCustomerClassName()) {
             return true;

--- a/src/Targeting/EventListener/ElementSegmentsListener.php
+++ b/src/Targeting/EventListener/ElementSegmentsListener.php
@@ -61,8 +61,10 @@ class ElementSegmentsListener implements EventSubscriberInterface
 
     /**
      * @inheritDoc
+     *
+     * @return array<string, string>
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents()//: array
     {
         return [
             TargetingEvents::PRE_RESOLVE => 'onTargetingPreResolve'

--- a/src/Targeting/EventListener/TargetingToolbarListener.php
+++ b/src/Targeting/EventListener/TargetingToolbarListener.php
@@ -52,7 +52,10 @@ class TargetingToolbarListener implements EventSubscriberInterface
         $this->segmentManager = $segmentManager;
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * @return array<string, string>
+     */
+    public static function getSubscribedEvents()//: array
     {
         return [
             TargetingEvents::RENDER_TOOLBAR => 'onRenderToolbar'


### PR DESCRIPTION
Deprecation from Codeception log:
```
DEPRECATION: Method "Pimcore\Model\Listing\AbstractListing::isValidOrderKey()" might add "bool" as a native return type declaration in the future. Do the same in child class "CustomerManagementFrameworkBundle\Model\ActionTrigger\Rule\Listing" now to avoid errors or add an explicit @return annotation to suppress this message. /home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/error-handler/DebugClassLoader.php:326
DEPRECATION: Method "Pimcore\Model\Listing\Dao\AbstractDao::load()" might add "array" as a native return type declaration in the future. Do the same in child class "CustomerManagementFrameworkBundle\Model\ActionTrigger\Rule\Listing\Dao" now to avoid errors or add an explicit @return annotation to suppress this message. /home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/error-handler/DebugClassLoader.php:326
DEPRECATION: Method "Pimcore\Model\Listing\AbstractListing::isValidOrderKey()" might add "bool" as a native return type declaration in the future. Do the same in child class "CustomerManagementFrameworkBundle\Model\ActivityList\DefaultMariaDbActivityList" now to avoid errors or add an explicit @return annotation to suppress this message. /home/runner/work/customer-data-framework/customer-data-framework/vendor/symfony/error-handler/DebugClassLoader.php:326
```

Other deprecations are from the Symfony Toolbar