### PR TITLE
[Task]: Quoting fields in actiontrigger_rules, activities_metadata 

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,14 +40,13 @@ jobs:
               with:
                   dependency-versions: "${{ matrix.dependencies }}"
 
-          -   name: "Run a static analysis with phpstan/phpstan (highest)"
+            - name: "Run a static analysis with phpstan/phpstan (highest)"
               if: ${{ matrix.dependencies == 'highest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1"
 
-          -   name: "Run a static analysis with phpstan/phpstan (lowest)"
+            - name: "Run a static analysis with phpstan/phpstan (lowest)"
               if: ${{ matrix.dependencies == 'lowest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"
-
 
             - name: "Generate baseline file"
               if: ${{ failure() }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -40,8 +40,14 @@ jobs:
               with:
                   dependency-versions: "${{ matrix.dependencies }}"
 
-            - name: "Run a static analysis with phpstan/phpstan"
+          -   name: "Run a static analysis with phpstan/phpstan (highest)"
+              if: ${{ matrix.dependencies == 'highest' }}
               run: "vendor/bin/phpstan analyse --memory-limit=-1"
+
+          -   name: "Run a static analysis with phpstan/phpstan (lowest)"
+              if: ${{ matrix.dependencies == 'lowest' }}
+              run: "vendor/bin/phpstan analyse --memory-limit=-1 -c phpstan-lowest.neon"
+
 
             - name: "Generate baseline file"
               if: ${{ failure() }}

--- a/phpstan-lowest.neon
+++ b/phpstan-lowest.neon
@@ -5,14 +5,14 @@ parameters:
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		-
-			message: "#Call to an undefined static method Pimcore\Db\Helper::quoteDataIdentifiers().#"
+			message: "#Call to an undefined static method Pimcore\\\Db\\\Helper\\:\\:quoteDataIdentifiers\\(\\).#"
 			count: 1
 			path: src/ActivityStore/MariaDb.php
 		-
-			message: "#Call to an undefined static method Pimcore\Db\Helper::quoteDataIdentifiers().#"
+			message: "#Call to an undefined static method Pimcore\\\Db\\\Helper\\:\\:quoteDataIdentifiers\\(\\).#"
 			count: 1
 			path: src/ActivityStore/SqlActivityStore.php
 		-
-			message: "#Call to an undefined static method Pimcore\Db\Helper::quoteDataIdentifiers().#"
+			message: "#Call to an undefined static method Pimcore\\\Db\\\Helper\\:\\:quoteDataIdentifiers\\(\\).#"
 			count: 2
 			path: src/Model/ActionTrigger/Rule/Dao.php

--- a/phpstan-lowest.neon
+++ b/phpstan-lowest.neon
@@ -1,0 +1,18 @@
+includes:
+    - phpstan.neon
+
+parameters:
+	reportUnmatchedIgnoredErrors: false
+	ignoreErrors:
+		-
+			message: "#Call to an undefined static method Pimcore\Db\Helper::quoteDataIdentifiers().#"
+			count: 1
+			path: src/ActivityStore/MariaDb.php
+		-
+			message: "#Call to an undefined static method Pimcore\Db\Helper::quoteDataIdentifiers().#"
+			count: 1
+			path: src/ActivityStore/SqlActivityStore.php
+		-
+			message: "#Call to an undefined static method Pimcore\Db\Helper::quoteDataIdentifiers().#"
+			count: 2
+			path: src/Model/ActionTrigger/Rule/Dao.php

--- a/phpstan-lowest.neon
+++ b/phpstan-lowest.neon
@@ -5,14 +5,14 @@ parameters:
 	reportUnmatchedIgnoredErrors: false
 	ignoreErrors:
 		-
-			message: "#Call to an undefined static method Pimcore\\\Db\\\Helper\\:\\:quoteDataIdentifiers\\(\\).#"
+			message: "#Call to an undefined static method Pimcore\\\\Db\\\\Helper\\:\\:quoteDataIdentifiers\\(\\)\\.#"
 			count: 1
 			path: src/ActivityStore/MariaDb.php
 		-
-			message: "#Call to an undefined static method Pimcore\\\Db\\\Helper\\:\\:quoteDataIdentifiers\\(\\).#"
+			message: "#Call to an undefined static method Pimcore\\\\Db\\\\Helper\\:\\:quoteDataIdentifiers\\(\\)\\.#"
 			count: 1
 			path: src/ActivityStore/SqlActivityStore.php
 		-
-			message: "#Call to an undefined static method Pimcore\\\Db\\\Helper\\:\\:quoteDataIdentifiers\\(\\).#"
+			message: "#Call to an undefined static method Pimcore\\\\Db\\\\Helper\\:\\:quoteDataIdentifiers\\(\\)\\.#"
 			count: 2
 			path: src/Model/ActionTrigger/Rule/Dao.php

--- a/src/ActivityStore/MariaDb.php
+++ b/src/ActivityStore/MariaDb.php
@@ -173,7 +173,7 @@ class MariaDb extends SqlActivityStore implements ActivityStoreInterface
                     ];
 
                     //TODO: Remove this if block when dropping Pimcore 10 support
-                    if (!class_exists('Pimcore\Db\Connection')) {
+                    if (!class_exists('\Pimcore\Db\Connection')) {
                         $insertData = Helper::quoteDataIdentifiers($db, $insertData);
                     }
 

--- a/src/ActivityStore/MariaDb.php
+++ b/src/ActivityStore/MariaDb.php
@@ -173,7 +173,7 @@ class MariaDb extends SqlActivityStore implements ActivityStoreInterface
                     ];
 
                     //TODO: Remove this if block when dropping Pimcore 10 support
-                    if (!class_exists("\Pimcore\Db\Connection")) {
+                    if (!class_exists('Pimcore\Db\Connection')) {
                         $insertData = Helper::quoteDataIdentifiers($db, $insertData);
                     }
 

--- a/src/ActivityStore/MariaDb.php
+++ b/src/ActivityStore/MariaDb.php
@@ -166,17 +166,18 @@ class MariaDb extends SqlActivityStore implements ActivityStoreInterface
                 $db->executeQuery('DELETE FROM ' . self::ACTIVITIES_METADATA_TABLE . ' WHERE activityId = ?', [(int)$entry->getId()]);
 
                 foreach ($entry->getMetadata() as $key => $data) {
-                    $db->insert(
-                        self::ACTIVITIES_METADATA_TABLE,
-                        Helper::quoteDataIdentifiers(
-                            $db,
-                            [
-                                'activityId' => $entry->getId(),
-                                'key' => $key,
-                                'data' => $data
-                            ]
-                        )
-                    );
+                    $insertData = [
+                        'activityId' => $entry->getId(),
+                        'key' => $key,
+                        'data' => $data
+                    ];
+
+                    //TODO: Remove this if block when dropping Pimcore 10 support
+                    if (!class_exists("\Pimcore\Db\Connection")) {
+                        $insertData = Helper::quoteDataIdentifiers($db, $insertData);
+                    }
+
+                    $db->insert(self::ACTIVITIES_METADATA_TABLE, $insertData);
                 }
             } catch (TableNotFoundException $ex) {
                 $this->getLogger()->error(sprintf('table %s not found - please press the update button of the CMF bundle in the extension manager', self::ACTIVITIES_METADATA_TABLE));

--- a/src/ActivityStore/MariaDb.php
+++ b/src/ActivityStore/MariaDb.php
@@ -172,7 +172,7 @@ class MariaDb extends SqlActivityStore implements ActivityStoreInterface
                         'data' => $data
                     ];
 
-                    //TODO: Remove this if block when dropping Pimcore 10 support
+                    //TODO: Remove this if expression when dropping Pimcore 10 support
                     if (!class_exists('\Pimcore\Db\Connection')) {
                         $insertData = Helper::quoteDataIdentifiers($db, $insertData);
                     }

--- a/src/ActivityStore/MariaDb.php
+++ b/src/ActivityStore/MariaDb.php
@@ -168,11 +168,14 @@ class MariaDb extends SqlActivityStore implements ActivityStoreInterface
                 foreach ($entry->getMetadata() as $key => $data) {
                     $db->insert(
                         self::ACTIVITIES_METADATA_TABLE,
-                        [
-                            'activityId' => $entry->getId(),
-                            'key' => $key,
-                            'data' => $data
-                        ]
+                        Helper::quoteDataIdentifiers(
+                            $db,
+                            [
+                                'activityId' => $entry->getId(),
+                                'key' => $key,
+                                'data' => $data
+                            ]
+                        )
                     );
                 }
             } catch (TableNotFoundException $ex) {

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -145,8 +145,6 @@ abstract class SqlActivityStore
                     }
 
                     $db->insert(self::ACTIVITIES_METADATA_TABLE, $insertData);
-
-
                 }
             } catch (TableNotFoundException $ex) {
                 $this->getLogger()->error(sprintf('table %s not found - please press the update button of the CMF bundle in the extension manager', self::ACTIVITIES_METADATA_TABLE));

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -117,14 +117,14 @@ abstract class SqlActivityStore
             if ($entry->getId()) {
                 $db->update(
                     self::ACTIVITIES_TABLE,
-                    $data,
+                    Helper::quoteDataIdentifiers($db, $data),
                     ['id' => $entry->getId()]
                 );
             } else {
                 $data['creationDate'] = $time;
                 $db->insert(
                     self::ACTIVITIES_TABLE,
-                    $data
+                    Helper::quoteDataIdentifiers($db, $data)
                 );
                 $entry->setId((int) $db->lastInsertId());
             }

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -140,7 +140,7 @@ abstract class SqlActivityStore
                     ];
 
                     //TODO: Remove this if block when dropping Pimcore 10 support
-                    if (!class_exists('Pimcore\Db\Connection')) {
+                    if (!class_exists('\Pimcore\Db\Connection')) {
                         $insertData = Helper::quoteDataIdentifiers($db, $insertData);
                     }
 

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -117,14 +117,14 @@ abstract class SqlActivityStore
             if ($entry->getId()) {
                 $db->update(
                     self::ACTIVITIES_TABLE,
-                    Helper::quoteDataIdentifiers($db, $data),
+                    $data,
                     ['id' => $entry->getId()]
                 );
             } else {
                 $data['creationDate'] = $time;
                 $db->insert(
                     self::ACTIVITIES_TABLE,
-                    Helper::quoteDataIdentifiers($db, $data)
+                    $data
                 );
                 $entry->setId((int) $db->lastInsertId());
             }

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -136,7 +136,7 @@ abstract class SqlActivityStore
                     $db->insert(
                         self::ACTIVITIES_METADATA_TABLE,
                         Helper::quoteDataIdentifiers(
-                            $this->db,
+                            $db,
                             [
                                 'activityId' => $entry->getId(),
                                 'key' => $key,

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -140,7 +140,7 @@ abstract class SqlActivityStore
                     ];
 
                     //TODO: Remove this if block when dropping Pimcore 10 support
-                    if (!class_exists("\Pimcore\Db\Connection")) {
+                    if (!class_exists('Pimcore\Db\Connection')) {
                         $insertData = Helper::quoteDataIdentifiers($db, $insertData);
                     }
 

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -133,17 +133,20 @@ abstract class SqlActivityStore
                 $db->executeQuery('DELETE FROM ' . self::ACTIVITIES_METADATA_TABLE . ' WHERE activityId = ?', [(int)$entry->getId()]);
 
                 foreach ($entry->getMetadata() as $key => $data) {
-                    $db->insert(
-                        self::ACTIVITIES_METADATA_TABLE,
-                        Helper::quoteDataIdentifiers(
-                            $db,
-                            [
-                                'activityId' => $entry->getId(),
-                                'key' => $key,
-                                'data' => $data
-                            ]
-                        )
-                    );
+                    $insertData = [
+                        'activityId' => $entry->getId(),
+                        'key' => $key,
+                        'data' => $data
+                    ];
+
+                    //TODO: Remove this if block when dropping Pimcore 10 support
+                    if (!class_exists("\Pimcore\Db\Connection")) {
+                        $insertData = Helper::quoteDataIdentifiers($db, $insertData);
+                    }
+
+                    $db->insert(self::ACTIVITIES_METADATA_TABLE, $insertData);
+
+
                 }
             } catch (TableNotFoundException $ex) {
                 $this->getLogger()->error(sprintf('table %s not found - please press the update button of the CMF bundle in the extension manager', self::ACTIVITIES_METADATA_TABLE));

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -135,11 +135,14 @@ abstract class SqlActivityStore
                 foreach ($entry->getMetadata() as $key => $data) {
                     $db->insert(
                         self::ACTIVITIES_METADATA_TABLE,
-                        [
-                            'activityId' => $entry->getId(),
-                            'key' => $key,
-                            'data' => $data
-                        ]
+                        Helper::quoteDataIdentifiers(
+                            $this->db,
+                            [
+                                'activityId' => $entry->getId(),
+                                'key' => $key,
+                                'data' => $data
+                            ]
+                        )
                     );
                 }
             } catch (TableNotFoundException $ex) {

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -139,7 +139,7 @@ abstract class SqlActivityStore
                         'data' => $data
                     ];
 
-                    //TODO: Remove this if block when dropping Pimcore 10 support
+                    //TODO: Remove this if expression when dropping Pimcore 10 support
                     if (!class_exists('\Pimcore\Db\Connection')) {
                         $insertData = Helper::quoteDataIdentifiers($db, $insertData);
                     }

--- a/src/DataTransformer/DuplicateIndex/Standard.php
+++ b/src/DataTransformer/DuplicateIndex/Standard.php
@@ -22,7 +22,7 @@ class Standard implements DataTransformerInterface
     public function transform($data, $options = [])
     {
         if ($data instanceof \DateTime) {
-            $data = $data->format(\DateTimeInteface::ISO8601);
+            $data = $data->format(\DateTime:ISO8601);
         }
 
         return trim(strtolower(str_replace('  ', ' ', $data)));

--- a/src/DataTransformer/DuplicateIndex/Standard.php
+++ b/src/DataTransformer/DuplicateIndex/Standard.php
@@ -22,7 +22,7 @@ class Standard implements DataTransformerInterface
     public function transform($data, $options = [])
     {
         if ($data instanceof \DateTime) {
-            $data = $data->format(\DateTime:ISO8601);
+            $data = $data->format(\DateTime::ISO8601);
         }
 
         return trim(strtolower(str_replace('  ', ' ', $data)));

--- a/src/DataTransformer/DuplicateIndex/Standard.php
+++ b/src/DataTransformer/DuplicateIndex/Standard.php
@@ -22,7 +22,7 @@ class Standard implements DataTransformerInterface
     public function transform($data, $options = [])
     {
         if ($data instanceof \DateTime) {
-            $data = $data->format(\DateTime::ISO8601);
+            $data = $data->format(\DateTimeInteface::ISO8601);
         }
 
         return trim(strtolower(str_replace('  ', ' ', $data)));

--- a/src/Model/ActionTrigger/Rule/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Dao.php
@@ -108,7 +108,7 @@ class Dao extends Model\Dao\AbstractDao
                 $this->saveActions();
 
                 //TODO: Remove this if block when dropping Pimcore 10 support
-                if (!class_exists('Pimcore\Db\Connection')) {
+                if (!class_exists('\Pimcore\Db\Connection')) {
                     $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
 
@@ -125,7 +125,7 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->beginTransaction();
             try {
                 //TODO: Remove this if block when dropping Pimcore 10 support
-                if (!class_exists('Pimcore\Db\Connection')) {
+                if (!class_exists('\Pimcore\Db\Connection')) {
                     $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
 

--- a/src/Model/ActionTrigger/Rule/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Dao.php
@@ -108,7 +108,7 @@ class Dao extends Model\Dao\AbstractDao
                 $this->saveActions();
 
                 //TODO: Remove this if block when dropping Pimcore 10 support
-                if (!class_exists("\Pimcore\Db\Connection")) {
+                if (!class_exists('Pimcore\Db\Connection')) {
                     $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
 
@@ -125,7 +125,7 @@ class Dao extends Model\Dao\AbstractDao
             $this->db->beginTransaction();
             try {
                 //TODO: Remove this if block when dropping Pimcore 10 support
-                if (!class_exists("\Pimcore\Db\Connection")) {
+                if (!class_exists('Pimcore\Db\Connection')) {
                     $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
 

--- a/src/Model/ActionTrigger/Rule/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Dao.php
@@ -109,7 +109,7 @@ class Dao extends Model\Dao\AbstractDao
 
                 //TODO: Remove this if block when dropping Pimcore 10 support
                 if (!class_exists("\Pimcore\Db\Connection")) {
-                    $data = Helper::quoteDataIdentifiers($db, $data);
+                    $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
 
                 $this->db->update(self::TABLE_NAME, $data, ['id' => $this->model->getId()]);
@@ -126,7 +126,7 @@ class Dao extends Model\Dao\AbstractDao
             try {
                 //TODO: Remove this if block when dropping Pimcore 10 support
                 if (!class_exists("\Pimcore\Db\Connection")) {
-                    $data = Helper::quoteDataIdentifiers($db, $data);
+                    $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
 
                 $this->db->insert(self::TABLE_NAME, $data);

--- a/src/Model/ActionTrigger/Rule/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Dao.php
@@ -107,7 +107,7 @@ class Dao extends Model\Dao\AbstractDao
             try {
                 $this->saveActions();
 
-                //TODO: Remove this if block when dropping Pimcore 10 support
+                //TODO: Remove this if expression when dropping Pimcore 10 support
                 if (!class_exists('\Pimcore\Db\Connection')) {
                     $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }
@@ -124,7 +124,7 @@ class Dao extends Model\Dao\AbstractDao
             $data['creationDate'] = time();
             $this->db->beginTransaction();
             try {
-                //TODO: Remove this if block when dropping Pimcore 10 support
+                //TODO: Remove this if expression when dropping Pimcore 10 support
                 if (!class_exists('\Pimcore\Db\Connection')) {
                     $data = Helper::quoteDataIdentifiers($this->db, $data);
                 }

--- a/src/Model/ActionTrigger/Rule/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Dao.php
@@ -107,7 +107,12 @@ class Dao extends Model\Dao\AbstractDao
             try {
                 $this->saveActions();
 
-                $this->db->update(self::TABLE_NAME, Helper::quoteDataIdentifiers($this->db, $data), ['id' => $this->model->getId()]);
+                //TODO: Remove this if block when dropping Pimcore 10 support
+                if (!class_exists("\Pimcore\Db\Connection")) {
+                    $data = Helper::quoteDataIdentifiers($db, $data);
+                }
+
+                $this->db->update(self::TABLE_NAME, $data, ['id' => $this->model->getId()]);
                 $this->db->commit();
             } catch (\Exception $e) {
                 $this->db->rollBack();
@@ -119,7 +124,12 @@ class Dao extends Model\Dao\AbstractDao
             $data['creationDate'] = time();
             $this->db->beginTransaction();
             try {
-                $this->db->insert(self::TABLE_NAME, Helper::quoteDataIdentifiers($this->db, $data));
+                //TODO: Remove this if block when dropping Pimcore 10 support
+                if (!class_exists("\Pimcore\Db\Connection")) {
+                    $data = Helper::quoteDataIdentifiers($db, $data);
+                }
+
+                $this->db->insert(self::TABLE_NAME, $data);
                 $this->model->setId($this->db->fetchOne('SELECT LAST_INSERT_ID();'));
                 $this->model->setCreationDate($data['creationDate']);
                 $this->saveActions();

--- a/src/Model/ActionTrigger/Rule/Dao.php
+++ b/src/Model/ActionTrigger/Rule/Dao.php
@@ -18,6 +18,7 @@ namespace CustomerManagementFrameworkBundle\Model\ActionTrigger\Rule;
 use CustomerManagementFrameworkBundle\Model\ActionTrigger\ActionDefinition;
 use CustomerManagementFrameworkBundle\Model\ActionTrigger\ConditionDefinition;
 use CustomerManagementFrameworkBundle\Model\ActionTrigger\TriggerDefinition;
+use Pimcore\Db\Helper;
 use Pimcore\Model;
 
 /**
@@ -106,7 +107,7 @@ class Dao extends Model\Dao\AbstractDao
             try {
                 $this->saveActions();
 
-                $this->db->update(self::TABLE_NAME, $data, ['id' => $this->model->getId()]);
+                $this->db->update(self::TABLE_NAME, Helper::quoteDataIdentifiers($this->db, $data), ['id' => $this->model->getId()]);
                 $this->db->commit();
             } catch (\Exception $e) {
                 $this->db->rollBack();
@@ -118,7 +119,7 @@ class Dao extends Model\Dao\AbstractDao
             $data['creationDate'] = time();
             $this->db->beginTransaction();
             try {
-                $this->db->insert(self::TABLE_NAME, $data);
+                $this->db->insert(self::TABLE_NAME, Helper::quoteDataIdentifiers($this->db, $data));
                 $this->model->setId($this->db->fetchOne('SELECT LAST_INSERT_ID();'));
                 $this->model->setCreationDate($data['creationDate']);
                 $this->saveActions();


### PR DESCRIPTION
`key`,`trigger` and `condition` are protected keyword in sql and need to be quoted, since 11 it's not automatically quoting the array key of `$data` anymore.

See https://github.com/pimcore/pimcore/pull/12917, https://github.com/pimcore/pimcore/issues/13392, https://github.com/pimcore/pimcore/pull/13373
