### PR TITLE
[Bug]: Replace deprecated (since php 7.2) date format

### DIFF
--- a/src/DataTransformer/DuplicateIndex/Standard.php
+++ b/src/DataTransformer/DuplicateIndex/Standard.php
@@ -22,7 +22,7 @@ class Standard implements DataTransformerInterface
     public function transform($data, $options = [])
     {
         if ($data instanceof \DateTime) {
-            $data = $data->format(\DateTime::ISO8601);
+            $data = $data->format(\DateTimeInterface::ATOM);
         }
 
         return trim(strtolower(str_replace('  ', ' ', $data)));


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6014195/200777833-18273c7b-2482-4288-a8f2-a0a791d9225e.png)

Notes:
There's a *tricky* thing, the new `DateInterface::ISO8601` is different than `DateTime::ISO8601`, we need to use `DateInterface::ATOM` to be truly compatible with ISO-8601 but `DateInterface::ISO8061`  to not BC BREAK
See documentation: https://www.php.net/manual/en/class.datetimeinterface.php#datetimeinterface.constants.iso8601
