### PR TITLE
[Task]: Small change to make it compatible with DBAL v4

### DIFF
--- a/src/Migrations/PimcoreX/Version20220316141955.php
+++ b/src/Migrations/PimcoreX/Version20220316141955.php
@@ -30,7 +30,7 @@ final class Version20220316141955 extends AbstractMigration
     public function up(Schema $schema): void
     {
         $cmfDeletionsTable = $schema->getTable('plugin_cmf_deletions');
-        if ($cmfDeletionsTable->hasPrimaryKey()) {
+        if ($cmfDeletionsTable->getPrimaryKey()) {
             $cmfDeletionsTable->dropPrimaryKey();
         }
     }


### PR DESCRIPTION
Swapping `has` with `get` which is in line with latest [recommended implementations](https://github.com/doctrine/dbal/pull/5731) and more future-proof, since the `has` method will be deprecated in v4, while `get` is supported in DBAL 2,3,4 
https://github.com/doctrine/dbal/blob/2.12.0/lib/Doctrine/DBAL/Schema/Table.php#L722
