### PR TITLE
[Task]: Bump Number Sequence Generator to v2 (support for Pimcore 10.6 & 11)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "guzzlehttp/guzzle": "^7.2",
     "knplabs/knp-components": "^3.5 || ^4.0",
     "pear/archive_tar": "^1.4.3",
-    "pimcore/number-sequence-generator": "^1.0.5",
+    "pimcore/number-sequence-generator": "2.x-dev as 2.99",
     "pimcore/object-merger": "^3.0 || ^4.0",
     "pimcore/pimcore": "^10.6 || 11.x-dev as 11.99.9",
     "pimcore/search-query-parser": "^1.3",


### PR DESCRIPTION
The main branch in that repo got recently renamed to 2.x
See https://github.com/pimcore/number-sequence-generator/issues?q=is%3Aclosed+milestone%3Av2.0.0