### PR TITLE
[Bug] Fixed JS namespace error

### DIFF
--- a/src/Resources/public/js/pimcore/report/custom/definitions/termSegmentBuilder.js
+++ b/src/Resources/public/js/pimcore/report/custom/definitions/termSegmentBuilder.js
@@ -11,7 +11,7 @@
  *  @license    http://www.pimcore.org/license     GPLv3 and PCL
  */
 
-if (typeof pimcore.report.custom != 'undefined') {
+if (typeof pimcore.report != 'undefined') {
     pimcore.registerNS("pimcore.report.custom.definition.termSegmentBuilder");
     pimcore.report.custom.definition.termSegmentBuilder = createTermSegmentBuilderClass();
 } else {


### PR DESCRIPTION
It should be enough to test if `pimcore.report` exists since the new namespace starts with `pimcore.bundle ...`.

![image](https://user-images.githubusercontent.com/16717695/221910309-8d6df66a-68aa-43dd-b067-c25e68460e8a.png)
