### PR TITLE
[Task] Verfiy identifyer quoting for formerly automatically quoted db calls

### DIFF
--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -113,8 +113,6 @@ abstract class SqlActivityStore
         $data['md5'] = md5(serialize($md5Data));
         $data['modificationDate'] = $time;
 
-
-
         $db->beginTransaction();
 
         try {

--- a/src/ActivityStore/SqlActivityStore.php
+++ b/src/ActivityStore/SqlActivityStore.php
@@ -113,10 +113,13 @@ abstract class SqlActivityStore
         $data['md5'] = md5(serialize($md5Data));
         $data['modificationDate'] = $time;
 
+
+
         $db->beginTransaction();
 
         try {
             if ($entry->getId()) {
+                $data = Helper::quoteDataIdentifiers($db, $data);
                 $db->update(
                     self::ACTIVITIES_TABLE,
                     $data,
@@ -124,6 +127,7 @@ abstract class SqlActivityStore
                 );
             } else {
                 $data['creationDate'] = $time;
+                $data = Helper::quoteDataIdentifiers($db, $data);
                 $db->insert(
                     self::ACTIVITIES_TABLE,
                     $data

--- a/src/Model/ActionTrigger/ActionDefinition/Dao.php
+++ b/src/Model/ActionTrigger/ActionDefinition/Dao.php
@@ -15,6 +15,7 @@
 
 namespace CustomerManagementFrameworkBundle\Model\ActionTrigger\ActionDefinition;
 
+use Pimcore\Db\Helper;
 use Pimcore\Model;
 
 /**
@@ -47,6 +48,7 @@ class Dao extends Model\Dao\AbstractDao
             'implementationClass' => $this->model->getImplementationClass(),
             'options' => json_encode($this->model->getOptions()),
         ];
+        $data = Helper::quoteDataIdentifiers($this->db, $data);
 
         if ($this->model->getId()) {
             $this->db->update(self::TABLE_NAME, $data, ['id' => $this->model->getId()]);


### PR DESCRIPTION
found these when trying to resolve https://github.com/pimcore/customer-data-framework/issues/370
Most of the change were already covered in #345 

Some of these keys might break when using MySQL instead of MariaDB

[TYPE](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#:~:text=TRUNCATE-,TYPE,-TYPES), [OPTIONS](https://dev.mysql.com/doc/refman/8.0/en/keywords.html#:~:text=OPTIONALLY%20(R)-,OPTIONS,-OR%20(R))