### PR TITLE
[Bug]: Fix Inheritable Segment query

### DIFF
--- a/src/Controller/Admin/SegmentAssignmentController.php
+++ b/src/Controller/Admin/SegmentAssignmentController.php
@@ -50,9 +50,9 @@ class SegmentAssignmentController extends AdminController
      */
     public function inheritableSegments(Request $request, SegmentManagerInterface $segmentManager)
     {
-        $id = $request->get('id') ?? '';
+        $id = $request->get('id');
         $type = $request->get('type');
-        if (!$type) {
+        if (!$type || !$id) {
             return $this->adminJson(['data' => []]);
         }
 

--- a/src/Controller/Admin/SegmentAssignmentController.php
+++ b/src/Controller/Admin/SegmentAssignmentController.php
@@ -59,9 +59,9 @@ class SegmentAssignmentController extends AdminController
         $db = \Pimcore\Db::get();
         $parentIdStatement = sprintf('SELECT :parentIdField FROM %s WHERE :idField = :value', $db->quoteIdentifier($type . 's'));
         $parentId = $db->fetchOne($parentIdStatement, [
-            'parentIdField' => $parentIdField,
+            'parentIdField' => $type === 'object' ? 'o_parentId' : 'parentId',
             'idField' => $idField,
-            'value' => $id
+            'value' => $type === 'object' ? 'o_id' : 'id'
         ]);
 
         $segments = $segmentManager->getSegmentsForElementId($parentId, $type);

--- a/src/Controller/Admin/SegmentAssignmentController.php
+++ b/src/Controller/Admin/SegmentAssignmentController.php
@@ -51,11 +51,16 @@ class SegmentAssignmentController extends AdminController
     public function inheritableSegments(Request $request, SegmentManagerInterface $segmentManager)
     {
         $id = $request->get('id') ?? '';
-        $type = $request->get('type') ?? '';
+        $type = $request->get('type');
+        if (!$type){
+            return $this->adminJson(['data' => []]);
+        }
 
         $db = \Pimcore\Db::get();
-        $parentIdStatement = sprintf('SELECT `%s` FROM `%s` WHERE `%s` = :value', $type === 'object' ? 'o_parentId' : 'parentId', $type.'s', $type === 'object' ? 'o_id' : 'id');
+        $parentIdStatement = sprintf('SELECT :parentIdField FROM %s WHERE :idField = :value', $db->quoteIdentifier($type . 's'));
         $parentId = $db->fetchOne($parentIdStatement, [
+            'parentIdField' => $parentIdField,
+            'idField' => $idField,
             'value' => $id
         ]);
 

--- a/src/Controller/Admin/SegmentAssignmentController.php
+++ b/src/Controller/Admin/SegmentAssignmentController.php
@@ -52,7 +52,7 @@ class SegmentAssignmentController extends AdminController
     {
         $id = $request->get('id') ?? '';
         $type = $request->get('type');
-        if (!$type){
+        if (!$type) {
             return $this->adminJson(['data' => []]);
         }
 

--- a/src/Controller/Admin/SegmentAssignmentController.php
+++ b/src/Controller/Admin/SegmentAssignmentController.php
@@ -60,8 +60,8 @@ class SegmentAssignmentController extends AdminController
         $parentIdStatement = sprintf('SELECT :parentIdField FROM %s WHERE :idField = :value', $db->quoteIdentifier($type . 's'));
         $parentId = $db->fetchOne($parentIdStatement, [
             'parentIdField' => $type === 'object' ? 'o_parentId' : 'parentId',
-            'idField' => $idField,
-            'value' => $type === 'object' ? 'o_id' : 'id'
+            'idField' => $type === 'object' ? 'o_id' : 'id',
+            'value' => $id
         ]);
 
         $segments = $segmentManager->getSegmentsForElementId($parentId, $type);


### PR DESCRIPTION
This `type` empty  string fallback doesn't make sense because the queru would be `SELECT * FROM s` (suffixed substring)