### PR TITLE
Fix action rule/save in Customer Automation Rules UI API

### DIFF
--- a/src/ActionTrigger/Action/AbstractAction.php
+++ b/src/ActionTrigger/Action/AbstractAction.php
@@ -44,8 +44,12 @@ abstract class AbstractAction implements ActionInterface
         $actionDelayMultiplier = isset(self::$actionDelayMultiplier[$setting->options->actionDelayGuiType]) ? self::$actionDelayMultiplier[$setting->options->actionDelayGuiType] : 1;
 
         $action = new \CustomerManagementFrameworkBundle\Model\ActionTrigger\ActionDefinition();
-        $action->setId($setting->id);
-        $action->setCreationDate($setting->creationDate);
+        if (isset($setting->id)) {
+            $action->setId($setting->id);
+        }
+        if (isset($setting->creationDate)) {
+            $action->setCreationDate($setting->creationDate);
+        }
         $action->setOptions(json_decode(json_encode($setting->options), true));
         $action->setImplementationClass($setting->implementationClass);
         $action->setActionDelay($setting->options->actionDelayGuiValue * $actionDelayMultiplier);


### PR DESCRIPTION
Creating a new entry in the Customer Automation Rules UI and specifying a *new* action in the "Actions" tab results in a failed save request of API call `/admin/customermanagementframework/rules/save` - The API results in a response `{success: false, message: "Warning: Undefined property: stdClass::$id"}` - The UI does *not* parse this response correctly as a flash popup note comes up stating "Success: Rule saved successfully".
This PR does not fix the wrong UI message, but the underlying reason for not being able to save the new action.
It is not (yet) known, if the error persists in the 4.0 branch, too.