### PR TITLE
fixed implementation of lockable trait

### DIFF
--- a/src/Newsletter/Command/NewsletterSyncCommand.php
+++ b/src/Newsletter/Command/NewsletterSyncCommand.php
@@ -89,7 +89,11 @@ class NewsletterSyncCommand extends AbstractCommand
         if ($input->getOption('customer-data-sync') || $input->getOption('all-customers')) {
             $lockKey = 'plugin_cmf_newsletter_sync_queue';
 
-            $this->lock($lockKey);
+            if (!$this->lock($lockKey)) {
+                $output->writeln('The command is already running in another process.');
+
+                return 0;
+            }
 
             if (!$input->getOption('force-segments')) {
                 $this->newsletterManager->syncSegments();


### PR DESCRIPTION
Currently the NewsletterSyncCommand can run in parallel as the lockable trait is used incorrectly. The command does not exit early if the lock couldn't be aquired.

[Symfony Documentation for Lockable trait](https://symfony.com/doc/current/console/lockable_trait.html)