### PR TITLE
Explicitly require pcntl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
   },
   "require": {
     "php": "~8.1.0 || ~8.2.0",
+    "ext-pcntl": "*",
     "openspout/openspout": "^4.0",
     "doctrine/dbal": "^3.4.2",
     "doctrine/migrations": "^3.0.2",


### PR DESCRIPTION
Issue discovered after upgrading to PHP 8.2 and Pimcore 11.

> [2023-10-16T17:55:07.861905+02:00] php.CRITICAL: Uncaught Error: Undefined constant "SIGTERM" {"exception":"[object] (Error(code: 0): Undefined constant \"SIGTERM\""} []

It is used here:

https://github.com/pimcore/customer-data-framework/blob/9e6c392f8fcb6cb41aff4d833a500fce631de36b/src/SegmentManager/SegmentBuilderExecutor/DefaultSegmentBuilderExecutor.php#L230-L232

And is installed in the default Docker files here:

https://github.com/pimcore/docker/blob/0c1adac7df7687469f2334d55bf0fe9405b64a71/Dockerfile#L32-L44

So it may not be too much of a blocker, but it should be made clear for those of us who have our own Dockerfiles.