### PR TITLE
Fix memory exhaustion when recreating customer duplicates-index

### DIFF
--- a/src/DuplicatesIndex/DefaultMariaDbDuplicatesIndex.php
+++ b/src/DuplicatesIndex/DefaultMariaDbDuplicatesIndex.php
@@ -117,6 +117,8 @@ class DefaultMariaDbDuplicatesIndex implements DuplicatesIndexInterface
 
                 $this->updateDuplicateIndexForCustomer($customer, true);
             }
+
+            \Pimcore::collectGarbage();
         }
     }
 


### PR DESCRIPTION
Fix for memory exhaustion when recreating customer duplicates index as per #511 