### PR TITLE
Add original customer id check

### DIFF
--- a/src/CustomerSaveManager/DefaultCustomerSaveManager.php
+++ b/src/CustomerSaveManager/DefaultCustomerSaveManager.php
@@ -128,7 +128,7 @@ class DefaultCustomerSaveManager implements CustomerSaveManagerInterface
             $originalCustomer = null;
         }
 
-        if ($originalCustomerNeeded) {
+        if ($originalCustomerNeeded && $customer->getId()) {
             $originalCustomer = $this->customerProvider->getById($customer->getId(), true);
         }
 


### PR DESCRIPTION
Using custom save handlers with isOriginalCustomerNeeded enabled, creating users always fails as Pimcore 11 requires string|int but the id is still null.

```
Message: Pimcore\Model\DataObject\AbstractObject::getById(): Argument #1 ($id) must be of type string|int, null given
Trace: 
in /app/vendor/pimcore/pimcore/models/DataObject/AbstractObject.php:203
#0 [internal function]: Pimcore\Model\DataObject\AbstractObject::getById(NULL, Array)
#1 /app/vendor/pimcore/customer-management-framework-bundle/src/CustomerProvider/DefaultCustomerProvider.php(300): call_user_func_array(Array, Array)
#2 /app/vendor/pimcore/customer-management-framework-bundle/src/CustomerProvider/DefaultCustomerProvider.php(219): CustomerManagementFrameworkBundle\CustomerProvider\DefaultCustomerProvider->callStatic('getById', Array)
#3 /app/vendor/pimcore/customer-management-framework-bundle/src/CustomerSaveManager/DefaultCustomerSaveManager.php(132): CustomerManagementFrameworkBundle\CustomerProvider\DefaultCustomerProvider->getById(NULL, true)
#4 /app/vendor/pimcore/customer-management-framework-bundle/src/CustomerSaveManager/DefaultCustomerSaveManager.php(140): CustomerManagementFrameworkBundle\CustomerSaveManager\DefaultCustomerSaveManager->rememberOriginalCustomer(Object(App\Model\DataObject\User))
```