### PR TITLE
[Task]: Bump minimum requirement for `pear/archive_tar`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "drewm/mailchimp-api": "^2.2",
     "guzzlehttp/guzzle": "^7.2",
     "knplabs/knp-components": "^4.0",
-    "pear/archive_tar": "^1.4.3",
+    "pear/archive_tar": "^1.4.14",
     "pimcore/newsletter-bundle": "^1.0",
     "pimcore/number-sequence-generator": "^2.0",
     "pimcore/admin-ui-classic-bundle": "^1.0",


### PR DESCRIPTION
Resolves https://github.com/pimcore/planning/issues/323

Jsut for safety and to include this fix https://github.com/advisories/GHSA-p8q8-jfcv-g2h2