### PR TITLE
Remove instruction to “generate type declarations” from the docs

### DIFF
--- a/doc/02_Installation/README.md
+++ b/doc/02_Installation/README.md
@@ -78,8 +78,7 @@ Following options to prepare the customer class are available:
   
 As starting point this [class definition](https://github.com/pimcore/customer-data-framework/blob/master/install/class_source/optional/class_Customer_export.json) can be used.
 
-Note that the class doesn't need to contain the attributes as field definitions. You can also just add the fields to your specific class implementation interface by adding getters. You **must** also enable the _Generate Type Declarations_ options on the `Customer` class for the attributes to be compatible with the `Interface`.
-  
+Note that the class doesn't need to contain the attributes as field definitions. You can also just add the fields to your specific class implementation interface by adding getters.
 
   Example
   ```php


### PR DESCRIPTION
This option has been removed in Pimcore 11: https://github.com/pimcore/pimcore/issues/12468

For the reference: https://github.com/orgs/pimcore/discussions/17268