### PR TITLE
Drop twig deferred blocks and deprecated pimcore_* twig extension calls

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,10 +23,10 @@ jobs:
                     - { php-version: "8.3", dependencies: "highest", pimcore_version: "11.x-dev as 11.3.9", experimental: true }
         steps:
             - name: "Checkout code"
-              uses: "actions/checkout@v2"
+              uses: "actions/checkout@v4"
 
             - name: "Install PHP"
-              uses: "shivammathur/setup-php@v2"
+              uses: shivammathur/setup-php@v2
               with:
                   coverage: "none"
                   php-version: "${{ matrix.php-version }}"
@@ -46,7 +46,7 @@ jobs:
                 fi    
 
             - name: "Install dependencies with Composer"
-              uses: "ramsey/composer-install@v2"
+              uses: ramsey/composer-install@v3
               with:
                   dependency-versions: "${{ matrix.dependencies }}"
 
@@ -64,7 +64,7 @@ jobs:
 
             - name: "Upload baseline file"
               if: ${{ failure() }}
-              uses: actions/upload-artifact@v2
+              uses: actions/upload-artifact@v4
               with:
                   name: phpstan-baseline.neon
                   path: phpstan-baseline.neon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### v4.2.0
+- Removed the package "rybakit/twig-deferred-extension"
+
 #### v4.0.0
  - Added primary key to `plugin_cmf_deletions` table.
  - Removed the package "hwi/oauth-bundle".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
-#### v4.2.0
-- Removed the package "rybakit/twig-deferred-extension"
+#### v4.1.2
+Removed the package "rybakit/twig-deferred-extension". If you extend the twig layout from the Customer Data Framework, please check if custom CSS/JS code added by pimcore_head_script and pimcore_head_link is still working.
 
 #### v4.0.0
  - Added primary key to `plugin_cmf_deletions` table.

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     "pimcore/pimcore": "^11.0",
     "pimcore/search-query-parser": "^1.3",
     "pimcore/personalization-bundle": "^1.0",
-    "rybakit/twig-deferred-extension": "^3.0",
     "symfony/asset": "^6.2",
     "symfony/config": "^6.2",
     "symfony/console": "^6.2",
@@ -52,9 +51,6 @@
     "phpstan/phpstan": "^1.9",
     "phpstan/phpstan-symfony": "^1.2.14",
     "phpunit/phpunit": "^9.5"
-  },
-  "conflict": {
-    "twig/twig": "^3.9.0"
   },
   "suggest": {
     "php-http/guzzle7-adapter": "^0.1.1",

--- a/doc/02_Installation/01_Update.md
+++ b/doc/02_Installation/01_Update.md
@@ -1,5 +1,8 @@
 # Update Notices
 
+## Update to Version 4.2
+- CSS includes using the `pimcore_head_link` view helper are not within a deferred block anymore. If you extend the CMF `layout.html.twig` template in your custom code and embed additional CSS within your templates via the `pimcore_head_link` twig extension, check if they still are embedded correctly.
+
 ## Update to Version 4
 - Execute SQL script `src/Resources/sql/segmentAssignment/storedFunctionObject.sql`, only for Pimcore 11.
 - Remove Single Sign On custom implementations & classes e.g. `SSOIdentity`, `OAuth1Token`, `OAuth2Token` and `ssoIdentities` field

--- a/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
+++ b/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
@@ -152,7 +152,7 @@ class DefaultObjectNamingScheme implements ObjectNamingSchemeInterface
         foreach ($namingScheme as $i => $namingSchemeItem) {
             preg_match_all('/{([a-zA-Z0-9]*)}/', $namingSchemeItem, $matchedPlaceholder);
 
-            if (count($matchedPlaceholder) > 0) {
+            if (count($matchedPlaceholder[0] ?? []) > 0) {
                 foreach ($matchedPlaceholder[0] as $j => $placeholder) {
                     $field = $matchedPlaceholder[1][$j];
 

--- a/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
+++ b/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
@@ -152,7 +152,7 @@ class DefaultObjectNamingScheme implements ObjectNamingSchemeInterface
         foreach ($namingScheme as $i => $namingSchemeItem) {
             preg_match_all('/{([a-zA-Z0-9]*)}/', $namingSchemeItem, $matchedPlaceholder);
 
-            if (count($matchedPlaceholder[0] ?? []) > 0) {
+            if (count($matchedPlaceholder[0]) > 0) {
                 foreach ($matchedPlaceholder[0] as $j => $placeholder) {
                     $field = $matchedPlaceholder[1][$j];
 

--- a/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
+++ b/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
@@ -152,7 +152,7 @@ class DefaultObjectNamingScheme implements ObjectNamingSchemeInterface
         foreach ($namingScheme as $i => $namingSchemeItem) {
             preg_match_all('/{([a-zA-Z0-9]*)}/', $namingSchemeItem, $matchedPlaceholder);
 
-            if (sizeof($matchedPlaceholder)) {
+            if (count($matchedPlaceholder) > 0) {
                 foreach ($matchedPlaceholder[0] as $j => $placeholder) {
                     $field = $matchedPlaceholder[1][$j];
 

--- a/src/Resources/config/services_templating.yml
+++ b/src/Resources/config/services_templating.yml
@@ -7,8 +7,3 @@ services:
     CustomerManagementFrameworkBundle\Twig\Extension\CmfUrlUtilsExtension:
         autowire: true
         tags: [ 'twig.extension' ]
-
-    # the deferred extension is needed for placeholder helpers to work
-    # as otherwise the placeholder block would be rendered before any
-    # content was added (e.g. headTitle)
-    Twig\DeferredExtension\DeferredExtension: ~

--- a/src/Resources/views/layout.html.twig
+++ b/src/Resources/views/layout.html.twig
@@ -12,7 +12,7 @@
         {% do pimcore_head_link().appendStylesheet(cmf_minifiedAssetUrl('/bundles/pimcorecustomermanagementframework/admin/css/cmf.css')) %}
     {% endapply %}
 
-    {% block head_stylesheets deferred %}
+    {% block head_stylesheets %}
         {{ pimcore_head_link() }}
     {% endblock %}
 </head>
@@ -25,16 +25,14 @@
 </div>
 
 {% do cmf_jsConfig().generateScriptTag(false) %}
-{% do pimcore_head_script().captureStart() %}
-{{ cmf_jsConfig()|raw }}
-{% do pimcore_head_script().captureEnd() %}
+{% do pimcore_head_script().appendScript(cmf_jsConfig()|raw ~ "") %}
 
 {% apply spaceless %}
     {% do pimcore_head_script().appendFile(cmf_minifiedAssetUrl('/bundles/pimcorecustomermanagementframework/admin/js/cmf.js')) %}
     {% do pimcore_head_script().prependFile(cmf_minifiedAssetUrl('/bundles/pimcorecustomermanagementframework/admin/js/lib.js')) %}
 {% endapply %}
 
-{% block headscripts deferred %}
+{% block headscripts %}
     {{ pimcore_head_script() }}
 {% endblock %}
 


### PR DESCRIPTION
Related to https://github.com/pimcore/pimcore/pull/17444

* Deferred blocks are not needed, everthing works without the `deferred` attribute too. As this extension does not work with twig >=3.9.0 it's removed now.
  * The only exception could be if someone extends the CMF layout in custom code and calls the `pimcore_head_link` extension within the content block. In that case the call would need to be moved outside of the content block. But that's a real edge case!

* The deprecated usage of `pimcore_head_script().captureStart()` is replaced with an alternative approach.
