### PR TITLE
Fix version number in update docs

### DIFF
--- a/doc/02_Installation/01_Update.md
+++ b/doc/02_Installation/01_Update.md
@@ -1,6 +1,6 @@
 # Update Notices
 
-## Update to Version 4.2
+## Update to Version 4.1.2
 - CSS includes using the `pimcore_head_link` view helper are not within a deferred block anymore. If you extend the CMF `layout.html.twig` template in your custom code and embed additional CSS within your templates via the `pimcore_head_link` twig extension, check if they still are embedded correctly.
 
 ## Update to Version 4


### PR DESCRIPTION
Apparently the plan is to release #540 in `v4.1.2` and not in `v4.2`.