### PR TITLE
[Bug]: Fix decline duplicates

### DIFF
--- a/src/Controller/Admin/DuplicatesController.php
+++ b/src/Controller/Admin/DuplicatesController.php
@@ -93,7 +93,7 @@ class DuplicatesController extends Admin
     {
         try {
             \Pimcore::getContainer()->get('cmf.customer_duplicates_index')->declinePotentialDuplicate(
-                $request->request->getInt('id')
+                $request->attributes->getInt('id')
             );
 
             return new JsonResponse(['success' => true]);


### PR DESCRIPTION
Resolves https://github.com/pimcore/customer-data-framework/issues/545


It was "clearly" `attributes` because of https://github.com/pimcore/customer-data-framework/blob/88990633a3e2201e0c9caeb382d1e23b6d36a888/src/Controller/Admin/DuplicatesController.php#L90 

UI still graphically removes the duplicate even on fail, that might have mislead me when checking the first time 🙈 