### PR TITLE
[Bug]: CMF Admin Customer List export id ambiguity

### DIFF
--- a/src/Controller/Admin/CustomersController.php
+++ b/src/Controller/Admin/CustomersController.php
@@ -164,9 +164,10 @@ class CustomersController extends Admin
         $listing = $this->buildListing($filters);
 
         $idField = Service::getVersionDependentDatabaseColumnName('id');
+        $fromTable = $listing->getQueryBuilder()->getQueryPart('from')[0]['table'];
         $query = $listing->getQueryBuilder()
             ->resetQueryPart('select')
-            ->select($idField);
+            ->select($fromTable . '.' . $idField);
         $ids = Db::get()->fetchFirstColumn((string)$query);
 
         $jobId = uniqid();
@@ -218,7 +219,9 @@ class CustomersController extends Admin
 
         $idField = Service::getVersionDependentDatabaseColumnName('id');
         $listing = $this->buildListing();
-        $listing->addConditionParam($idField . ' in ('.implode(', ', $ids).')');
+
+        $fromTable = $listing->getQueryBuilder()->getQueryPart('from')[0]['table'];
+        $listing->addConditionParam($fromTable . '.' . $idField . ' in ('.implode(', ', $ids).')');
 
         $exporter = $this->getExporter($listing, $data['exporter']);
         $exportData = $exporter->getExportData();


### PR DESCRIPTION
Resolves https://github.com/pimcore/customer-data-framework/issues/544

Applying from the suggestion in the issue but yep, it's not the ideal, because the `getQueryPart` is [deprecated](https://github.com/doctrine/dbal/pull/6179) and would affect https://github.com/pimcore/customer-data-framework/pull/537