### PR TITLE
Support nesting customer objects again

### DIFF
--- a/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
+++ b/src/CustomerProvider/ObjectNamingScheme/DefaultObjectNamingScheme.php
@@ -76,7 +76,11 @@ class DefaultObjectNamingScheme implements ObjectNamingSchemeInterface
 
         $parentPath = $this->correctPath($parentPath);
 
-        $customer->setParent(Service::createFolderByPath($parentPath));
+        if ($parent = Service::getElementByPath('object', $parentPath)) {
+            $customer->setParent($parent);
+        } else {
+            $customer->setParent(Service::createFolderByPath($parentPath));
+        }
 
         if (!$customer->getKey()) {
             $customer->setKey(uniqid());


### PR DESCRIPTION
With this PR the `DefaultObjectNamingScheme` supports nesting Customer objects again - like it was possible in v3. 

In Pimcore 11 stricter return types got introduced, which may result in a return type error, if customers got saved within other customer objects and not within folders.

There is a possible return type missmatch in https://github.com/pimcore/pimcore/blob/11.5/models/Element/Service.php#L817 and https://github.com/pimcore/pimcore/blob/11.5/models/Element/Service.php#L842. Also see https://github.com/pimcore/pimcore/blob/11.5/models/Element/Service.php#L427