### PR TITLE
Fix typo seen while building calculated segments

### DIFF
--- a/src/SegmentManager/SegmentBuilderExecutor/DefaultSegmentBuilderExecutor.php
+++ b/src/SegmentManager/SegmentBuilderExecutor/DefaultSegmentBuilderExecutor.php
@@ -223,7 +223,7 @@ class DefaultSegmentBuilderExecutor implements SegmentBuilderExecutorInterface
                     )
                 );
             };
-            $logger->warning('Enabling signal listeing (Ctrl+C, Kill) during processing...');
+            $logger->warning('Enabling signal listening (Ctrl+C, Kill) during processing...');
             // kill
             @pcntl_signal(SIGTERM, $stopProcessingHook);
             // capture ctrl+c


### PR DESCRIPTION
Fixes the following typo:

```bash
php bin/console cmf:build-segments
08:35:33 WARNING   [cmf] Enabling signal listeing (Ctrl+C, Kill) during processing...
```